### PR TITLE
Add parquet writing support

### DIFF
--- a/.memory/api.md
+++ b/.memory/api.md
@@ -31,6 +31,7 @@
 **Write:** Response is always `200 OK`. Request format is determined by `Content-Type` header:
 - `application/json` (default) → `{"columns": {"col1": [v1, v2], ...}}` (needs table schema to know column types)
 - `application/vnd.apache.arrow.stream` → Arrow IPC stream bytes (self-describing, no schema lookup needed)
+- `application/vnd.apache.parquet` → Parquet bytes (self-describing, no schema lookup needed). Uses `ParquetRecordBatchReaderBuilder` to read all row groups, then `concat_batches` to merge into a single `RecordBatch`.
 
 ## RecordBatch ↔ JSON Conversion (`convert.rs`)
 
@@ -70,4 +71,4 @@ The API schema lives in `openapi.yaml` (OpenAPI 3.1, YAML for human editability)
 ## Testing
 
 - Unit tests in `convert.rs`: direct conversion + round-trip tests for both directions
-- E2E tests in `tests/api_test.rs`: uses `tower::ServiceExt::oneshot()` against the `Router` — no real TCP server needed. Covers full create→write(JSON)→write(Arrow)→fetch(JSON)→fetch(Arrow) flow, plus OpenAPI endpoint validation.
+- E2E tests in `tests/api_test.rs`: uses `tower::ServiceExt::oneshot()` against the `Router` — no real TCP server needed. Covers full create→write(JSON)→write(Arrow)→write(Parquet)→fetch(JSON)→fetch(Arrow) flow, plus OpenAPI endpoint validation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,6 +550,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1616,6 +1622,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1865,6 +1877,7 @@ dependencies = [
  "memmap2",
  "murr",
  "ouroboros",
+ "parquet",
  "rand",
  "rayon",
  "redis",
@@ -1951,6 +1964,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ordered-multimap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1985,6 +2007,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "parquet"
+version = "57.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ee96b29972a257b855ff2341b37e61af5f12d6af1158b6dcdb5b31ea07bb3cb"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "paste",
+ "seq-macro",
+ "thrift",
+ "twox-hash",
+]
+
+[[package]]
 name = "parse-display"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2008,6 +2058,12 @@ dependencies = [
  "structmeta",
  "syn",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pathdiff"
@@ -2583,6 +2639,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2938,6 +3000,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3184,6 +3257,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typeid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ log = { version = "0.4.29", features = ["kv"] }
 env_logger = "0.11"
 clap = { version = "4.5.54", features = ["derive"] }
 arrow = { version = "57", default-features = true, features = ["ipc"] }
+parquet = { version = "57", default-features = false, features = ["arrow"] }
 tokio = { version = "1", features = ["rt-multi-thread", "fs", "time", "sync", "macros"] }
 tokio-stream = "0.1"
 async-trait = "0.1"


### PR DESCRIPTION
#  Summary
                                                                                                                                                                                                                  
  - Add Parquet as a third supported write format alongside JSON and Arrow IPC, dispatched via Content-Type: application/vnd.apache.parquet                                                                     
  - Parquet is self-describing (like Arrow IPC), so no schema lookup is needed — the handler reads all row groups with ParquetRecordBatchReaderBuilder and merges them into a single RecordBatch
  - Add E2E test covering the full create → write(Parquet) → fetch → verify flow

#  Test plan

  - cargo check compiles
  - cargo test — all 76 tests pass (69 unit + 7 E2E), including new test_write_parquet
