### PR TITLE
add table bench

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,16 +55,21 @@ harness = false
 name = "hashmap_row_bench"
 harness = false
 
-[profile.bench]                                                                                                                                                                                                 
-debug = true              # Include debug symbols (DWARF)                                                                                                                                                       
-# force-frame-pointers = true  # Required for stack sampling (Rust 1.79+)
-# opt-level = 2        # Less aggressive inlining                                                                                                                                                                 
-# lto = false          # Disable LTO     
+[[bench]]
+name = "table_bench"
+harness = false
 
-[profile.bench.build-override]                                                                                                                                                                                  
-debug = true                                                                                                                                                                                                    
+[profile.bench]
+debug = 1                   # line tables + symbols (good enough for perf)
+lto = false                 # optional: makes disasm easier to read
+codegen-units = 1           # optional: more stable codegen
+panic = "abort"             # optional
+force-frame-pointers = true
+
+[profile.bench.build-override]
+debug = true
 # force-frame-pointers = true                                                                                                                                                                                     
-                                                                                                                                                                                                                
-[profile.bench.package."*"]                                                                                                                                                                                     
-debug = true                                                                                                                                                                                                    
-# force-frame-pointers = true 
+
+[profile.bench.package."*"]
+debug = true
+# force-frame-pointers = true

--- a/benches/table_bench.rs
+++ b/benches/table_bench.rs
@@ -1,0 +1,91 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use arrow::datatypes::{DataType, Field, Schema};
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use tempfile::TempDir;
+use tokio::runtime::Runtime;
+
+use murr::core::{ColumnConfig, DType, TableSchema};
+use murr::service::MurrService;
+use murr::testutil::{bench_column_names, bench_generate_keys, generate_batch};
+
+const NUM_ROWS: usize = 10_000_000;
+const NUM_KEYS: usize = 1000;
+
+fn make_schema(col_names: &[String]) -> (TableSchema, Arc<Schema>) {
+    let mut columns = HashMap::new();
+    columns.insert(
+        "key".to_string(),
+        ColumnConfig {
+            dtype: DType::Utf8,
+            nullable: false,
+        },
+    );
+    let mut arrow_fields = vec![Field::new("key", DataType::Utf8, false)];
+
+    for name in col_names {
+        columns.insert(
+            name.clone(),
+            ColumnConfig {
+                dtype: DType::Float32,
+                nullable: false,
+            },
+        );
+        arrow_fields.push(Field::new(name, DataType::Float32, false));
+    }
+
+    let table_schema = TableSchema {
+        name: "bench".to_string(),
+        key: "key".to_string(),
+        columns,
+    };
+    let arrow_schema = Arc::new(Schema::new(arrow_fields));
+    (table_schema, arrow_schema)
+}
+
+fn bench_table_get(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+
+    let col_names = bench_column_names();
+    let (table_schema, arrow_schema) = make_schema(&col_names);
+
+    let dir = TempDir::new().unwrap();
+    let svc = Arc::new(MurrService::new(dir.path().to_path_buf()));
+
+    // Create table and write a single segment with 10M rows.
+    rt.block_on(async {
+        svc.create("bench", table_schema).await.unwrap();
+        let batch = generate_batch(&arrow_schema, NUM_ROWS);
+        svc.write("bench", &batch).await.unwrap();
+    });
+
+    let col_refs: Vec<&str> = col_names.iter().map(|s| s.as_str()).collect();
+    let keys = bench_generate_keys(NUM_KEYS, NUM_ROWS);
+    let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+
+    let mut group = c.benchmark_group(format!("table/rows_{}", NUM_ROWS));
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(30));
+    group.warm_up_time(Duration::from_secs(5));
+    group.throughput(Throughput::Elements(NUM_KEYS as u64));
+
+    group.bench_with_input(BenchmarkId::new("keys", NUM_KEYS), &NUM_KEYS, |b, _| {
+        b.to_async(&rt).iter(|| {
+            let svc = svc.clone();
+            let key_refs = key_refs.clone();
+            let col_refs = col_refs.clone();
+            async move {
+                svc.read("bench", black_box(&key_refs), black_box(&col_refs))
+                    .await
+                    .unwrap()
+            }
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_table_get);
+criterion_main!(benches);


### PR DESCRIPTION
  Top-level breakdown                                                                                                                                                                                             
   ```
  ┌───────┬───────────────────────────────────────────┐                                                                                                                                                           
  │ % CPU │                 Function                  │                                                                                                                                                         
  ├───────┼───────────────────────────────────────────┤
  │ 33.2% │ Float32Column::get_indexes                │
  ├───────┼───────────────────────────────────────────┤
  │ 25.7% │ TableReader::get                          │
  ├───────┼───────────────────────────────────────────┤
  │ 8.2%  │ exp (criterion KDE stats — ignore)        │
  ├───────┼───────────────────────────────────────────┤
  │ 4.9%  │ hash_one (key hashing)                    │
  ├───────┼───────────────────────────────────────────┤
  │ 3.5%  │ rayon (criterion internals)               │
  ├───────┼───────────────────────────────────────────┤
  │ 3.4%  │ __memcmp_evex_movbe (hash key comparison) │
  ├───────┼───────────────────────────────────────────┤
  │ 2.5%  │ malloc                                    │
  ├───────┼───────────────────────────────────────────┤
  │ 1.9%  │ TableReader::from_table                   │
  ├───────┼───────────────────────────────────────────┤
  │ 1.6%  │ hashbrown::reserve_rehash                 │
  └───────┴───────────────────────────────────────────┘
```
  Hotspot 1: Float32Column::get_indexes (33.2%)

  The non-nullable inner loop (lines 455–501 of the annotation) is where all the time goes. The hottest instructions:
```
  ┌────────┬──────────────────────────────────────────────────────────────────────────────┐
  │ Cycles │                                     What                                     │
  ├────────┼──────────────────────────────────────────────────────────────────────────────┤
  │ 12.73% │ cmp (%rsi),%edi — bounds check: segment_offset >= seg.header.num_values      │
  ├────────┼──────────────────────────────────────────────────────────────────────────────┤
  │ 7.01%  │ mov (%rbx),%edi — loading segment_offset from KeyOffset enum                 │
  ├────────┼──────────────────────────────────────────────────────────────────────────────┤
  │ 6.95%  │ cmp %rdi,%rsi — second bounds check: payload slice indexing                  │
  ├────────┼──────────────────────────────────────────────────────────────────────────────┤
  │ 6.71%  │ mov (%r12),%rsi — loading seg.header pointer                                 │
  ├────────┼──────────────────────────────────────────────────────────────────────────────┤
  │ 6.60%  │ cmpb $0x0,-0x8(%rbx) — enum discriminant check (MissingKey vs SegmentOffset) │
  ├────────┼──────────────────────────────────────────────────────────────────────────────┤
  │ 6.33%  │ branch on discriminant                                                       │
  ├────────┼──────────────────────────────────────────────────────────────────────────────┤
  │ 6.29%  │ loading seg.payload pointer                                                  │
  ├────────┼──────────────────────────────────────────────────────────────────────────────┤
  │ 3.57%  │ movss — the actual f32 read from payload                                     │
  ├────────┼──────────────────────────────────────────────────────────────────────────────┤
  │ 3.42%  │ movss — the actual f32 write to output                                       │
  └────────┴──────────────────────────────────────────────────────────────────────────────┘
```
  Key observations:
  - The actual data movement (movss load + store) is only ~7% of the function. The rest is overhead: bounds checks, enum discriminant checks, and pointer chasing.
  - There are 3 bounds checks per iteration: (1) segment_id in-bounds, (2) segment_offset < num_values, (3) output values[i] in-bounds. Each involves a branch.
  - The KeyOffset enum is being matched per element with a byte compare + conditional jump. Since the benchmark has no missing keys, this branch is always the same direction but still costs cycles.
  - Pointer chasing: each iteration loads seg from self.segments[segment_id], then loads seg.header, then loads seg.payload — all through indirection. With 1 segment, the segment lookup is always the same, but
  the compiler doesn't know that.

  Optimization ideas for get_indexes:
  1. Group by segment: sort/partition indexes by segment_id first, then process each segment's batch contiguously. This eliminates the per-element segment lookup and lets you hoist the segment pointer + header
  outside the inner loop.
  2. Use unsafe / get_unchecked: after a single upfront validation pass, use unchecked indexing in the hot loop to eliminate the 3 bounds checks per element.
  3. Separate missing keys: split indexes into two passes — first handle SegmentOffset entries (the common case), then fill in MissingKey nulls. This removes the discriminant branch from the hot path.
  4. Pre-split KeyOffset: if TableReader::get resolves keys into a struct-of-arrays (segment_ids: Vec<u32>, offsets: Vec<u32>, missing: BitVec) instead of Vec<KeyOffset> enum, the hot loop can iterate dense
  arrays without enum matching.

  Hotspot 2: TableReader::get (25.7%)

  The cost is dominated by keys.iter().map(|key| self.index.get(key).copied()...).collect() — the key lookup loop:
```
  ┌────────┬─────────────────────────────────────────────────────────────────────────┐
  │ Cycles │                                  What                                   │
  ├────────┼─────────────────────────────────────────────────────────────────────────┤
  │ 10.6%  │ Vec::extend_trusted / collect — allocation + filling the Vec<KeyOffset> │
  ├────────┼─────────────────────────────────────────────────────────────────────────┤
  │ 5.0%   │ iterator pointer arithmetic (NonNull::add)                              │
  ├────────┼─────────────────────────────────────────────────────────────────────────┤
  │ 2.8%   │ SlicePartialEq::equal — hash key string comparison                      │
  ├────────┼─────────────────────────────────────────────────────────────────────────┤
  │ 1.8%   │ Option::copied                                                          │
  ├────────┼─────────────────────────────────────────────────────────────────────────┤
  │ 1.5%   │ hashbrown::make_hash — hashing the key                                  │
  ├────────┼─────────────────────────────────────────────────────────────────────────┤
  │ 1.1%   │ Tag::full — hash probe                                                  │
  └────────┴─────────────────────────────────────────────────────────────────────────┘
```
  Key observations:
  - The .collect() into Vec<KeyOffset> allocates a new Vec every call. With 1000 keys this is small, but the iterator overhead (fold, map closures, extend_trusted) adds up to ~15%.
  - Hash lookups (make_hash + find_inner + string compare) are ~6% total, which is reasonable for 1000 lookups in a 10M-entry map.

  Optimization ideas for get:
  1. Reuse allocation: accept a &mut Vec<KeyOffset> buffer that gets cleared + reused across calls instead of allocating a new one each time.
  2. Pre-size and write directly: use Vec::with_capacity(keys.len()) + a manual loop with push instead of collect() to reduce iterator adapter overhead.
  3. Batch column retrieval: currently calls col.get_indexes(&key_offsets) per column sequentially. Since columns are independent, they could be processed in parallel (rayon).

  Summary of biggest wins (estimated impact)

  1. Eliminate bounds checks in get_indexes hot loop (~20% of total) — the single biggest win. The segment_offset < num_values check alone is 12.7% of total cycles.
  2. Group-by-segment in get_indexes (~10%) — eliminates per-element segment pointer chasing and enables sequential memory access within each segment's payload.
  3. Avoid allocation in get (~5%) — reuse the key_offsets buffer across iterations.
  4. Restructure KeyOffset to struct-of-arrays (~5%) — eliminates enum discriminant branching and improves data locality.
