### PR TITLE
Add redis benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,6 +733,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -1070,6 +1080,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1231,6 +1256,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1382,6 +1426,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1426,23 +1471,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1626,6 +1692,22 @@ name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "is-terminal"
@@ -1881,6 +1963,7 @@ dependencies = [
  "rand",
  "rayon",
  "redis",
+ "reqwest",
  "rstest",
  "serde",
  "serde_json",
@@ -1893,6 +1976,23 @@ dependencies = [
  "tokio-stream",
  "tower",
  "tower-http",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1958,10 +2058,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "ordered-float"
@@ -2131,6 +2269,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plotters"
@@ -2411,6 +2555,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2616,7 +2800,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2910,6 +3094,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -2920,6 +3107,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3097,6 +3305,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3212,9 +3430,12 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags 2.11.0",
  "bytes",
+ "futures-util",
  "http",
  "http-body",
+ "iri-string",
  "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3338,6 +3559,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3397,6 +3624,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe88540d1c934c4ec8e6db0afa536876c5441289d7f9f9123d4f065ac1250a6b"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -3546,6 +3787,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ tower = { version = "0.5", features = ["util"] }
 redis = { version = "0.27", features = ["tokio-comp", "connection-manager"] }
 testcontainers = "0.23"
 testcontainers-modules = { version = "0.11", features = ["redis"] }
+reqwest = { version = "0.12", features = ["json"] }
 
 [[bench]]
 name = "hashmap_bench"
@@ -57,6 +58,18 @@ harness = false
 
 [[bench]]
 name = "table_bench"
+harness = false
+
+[[bench]]
+name = "api_bench"
+harness = false
+
+[[bench]]
+name = "redis_featureblob_bench"
+harness = false
+
+[[bench]]
+name = "redis_feast_bench"
 harness = false
 
 [profile.bench]

--- a/benches/api_bench.rs
+++ b/benches/api_bench.rs
@@ -1,0 +1,70 @@
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use serde_json::json;
+use tokio::runtime::Runtime;
+
+use murr::api::MurrApi;
+use murr::testutil::{bench_column_names, bench_generate_keys};
+
+mod benchutil;
+use benchutil::{NUM_KEYS, NUM_ROWS};
+
+fn bench_api_fetch(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+
+    let col_names = bench_column_names();
+    let (_dir, svc) = benchutil::setup_service(&rt);
+
+    let api = MurrApi::new(svc);
+    let router = api.router();
+
+    // Bind to an OS-assigned port and spawn the server.
+    let port = rt.block_on(async {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+        port
+    });
+
+    let client = reqwest::Client::new();
+    let url = format!("http://127.0.0.1:{port}/api/v1/table/bench/fetch");
+
+    let keys = bench_generate_keys(NUM_KEYS, NUM_ROWS);
+    let fetch_body = json!({
+        "keys": keys,
+        "columns": col_names,
+    });
+
+    let mut group = c.benchmark_group(format!("api/rows_{}", NUM_ROWS));
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(30));
+    group.warm_up_time(Duration::from_secs(5));
+    group.throughput(Throughput::Elements(NUM_KEYS as u64));
+
+    group.bench_with_input(BenchmarkId::new("keys", NUM_KEYS), &NUM_KEYS, |b, _| {
+        b.to_async(&rt).iter(|| {
+            let client = client.clone();
+            let url = url.clone();
+            let fetch_body = fetch_body.clone();
+            async move {
+                let response = client
+                    .post(&url)
+                    .header("accept", "application/vnd.apache.arrow.stream")
+                    .json(&fetch_body)
+                    .send()
+                    .await
+                    .unwrap();
+                let bytes = response.bytes().await.unwrap();
+                black_box(bytes)
+            }
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_api_fetch);
+criterion_main!(benches);

--- a/benches/redis_feast_bench.rs
+++ b/benches/redis_feast_bench.rs
@@ -1,0 +1,79 @@
+use std::collections::HashMap;
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::redis::{Redis, REDIS_PORT};
+use tokio::runtime::Runtime;
+
+use murr::testutil::{bench_column_names, bench_generate_keys};
+
+mod benchutil;
+use benchutil::{NUM_KEYS, NUM_ROWS};
+
+const PIPELINE_BATCH: usize = 10_000;
+
+fn bench_redis_feast(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let col_names = bench_column_names();
+
+    // Start Redis container.
+    let (mut con, container) = rt.block_on(async {
+        let container = Redis::default().start().await.unwrap();
+        let host = container.get_host().await.unwrap();
+        let port = container.get_host_port_ipv4(REDIS_PORT).await.unwrap();
+        let client = redis::Client::open(format!("redis://{host}:{port}")).unwrap();
+        let con = client
+            .get_multiplexed_tokio_connection()
+            .await
+            .unwrap();
+        (con, container)
+    });
+
+    // Load 10M rows as Feast-style HSETs: key -> {col0: f32_bytes, col1: f32_bytes, ...}
+    rt.block_on(async {
+        for batch_start in (0..NUM_ROWS).step_by(PIPELINE_BATCH) {
+            let batch_end = (batch_start + PIPELINE_BATCH).min(NUM_ROWS);
+            let mut pipe = redis::pipe();
+            for i in batch_start..batch_end {
+                let key = i.to_string();
+                let fields: Vec<(&str, Vec<u8>)> = col_names
+                    .iter()
+                    .map(|name| (name.as_str(), (i as f32).to_le_bytes().to_vec()))
+                    .collect();
+                pipe.hset_multiple(key, &fields).ignore();
+            }
+            pipe.query_async::<()>(&mut con).await.unwrap();
+        }
+    });
+
+    let keys = bench_generate_keys(NUM_KEYS, NUM_ROWS);
+
+    let mut group = c.benchmark_group(format!("redis_feast/rows_{}", NUM_ROWS));
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(30));
+    group.warm_up_time(Duration::from_secs(5));
+    group.throughput(Throughput::Elements(NUM_KEYS as u64));
+
+    group.bench_with_input(BenchmarkId::new("keys", NUM_KEYS), &NUM_KEYS, |b, _| {
+        b.to_async(&rt).iter(|| {
+            let mut con = con.clone();
+            let keys = keys.clone();
+            async move {
+                let mut pipe = redis::pipe();
+                for key in &keys {
+                    pipe.hgetall(key);
+                }
+                let result: Vec<HashMap<String, Vec<u8>>> =
+                    pipe.query_async(&mut con).await.unwrap();
+                black_box(result)
+            }
+        })
+    });
+
+    group.finish();
+    rt.block_on(async { drop(container) });
+}
+
+criterion_group!(benches, bench_redis_feast);
+criterion_main!(benches);

--- a/benches/redis_featureblob_bench.rs
+++ b/benches/redis_featureblob_bench.rs
@@ -1,0 +1,72 @@
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use redis::AsyncCommands;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::redis::{Redis, REDIS_PORT};
+use tokio::runtime::Runtime;
+
+use murr::testutil::{bench_generate_keys, BENCH_NUM_COLUMNS};
+
+mod benchutil;
+use benchutil::{NUM_KEYS, NUM_ROWS};
+
+const PIPELINE_BATCH: usize = 10_000;
+
+fn bench_redis_featureblob(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+
+    // Start Redis container.
+    let (mut con, container) = rt.block_on(async {
+        let container = Redis::default().start().await.unwrap();
+        let host = container.get_host().await.unwrap();
+        let port = container.get_host_port_ipv4(REDIS_PORT).await.unwrap();
+        let client = redis::Client::open(format!("redis://{host}:{port}")).unwrap();
+        let con = client
+            .get_multiplexed_tokio_connection()
+            .await
+            .unwrap();
+        (con, container)
+    });
+
+    // Load 10M rows as feature blobs: key -> [f32; NUM_COLUMNS] as bytes.
+    rt.block_on(async {
+        for batch_start in (0..NUM_ROWS).step_by(PIPELINE_BATCH) {
+            let batch_end = (batch_start + PIPELINE_BATCH).min(NUM_ROWS);
+            let mut pipe = redis::pipe();
+            for i in batch_start..batch_end {
+                let key = i.to_string();
+                let blob: Vec<u8> = (0..BENCH_NUM_COLUMNS)
+                    .flat_map(|_| (i as f32).to_le_bytes())
+                    .collect();
+                pipe.set(key, blob).ignore();
+            }
+            pipe.query_async::<()>(&mut con).await.unwrap();
+        }
+    });
+
+    let keys = bench_generate_keys(NUM_KEYS, NUM_ROWS);
+
+    let mut group = c.benchmark_group(format!("redis_featureblob/rows_{}", NUM_ROWS));
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(30));
+    group.warm_up_time(Duration::from_secs(5));
+    group.throughput(Throughput::Elements(NUM_KEYS as u64));
+
+    group.bench_with_input(BenchmarkId::new("keys", NUM_KEYS), &NUM_KEYS, |b, _| {
+        b.to_async(&rt).iter(|| {
+            let mut con = con.clone();
+            let keys = keys.clone();
+            async move {
+                let result: Vec<Option<Vec<u8>>> = con.mget(&keys).await.unwrap();
+                black_box(result)
+            }
+        })
+    });
+
+    group.finish();
+    rt.block_on(async { drop(container) });
+}
+
+criterion_group!(benches, bench_redis_featureblob);
+criterion_main!(benches);

--- a/benches/table_bench.rs
+++ b/benches/table_bench.rs
@@ -1,65 +1,20 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use arrow::datatypes::{DataType, Field, Schema};
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
-use tempfile::TempDir;
 use tokio::runtime::Runtime;
 
-use murr::core::{ColumnConfig, DType, TableSchema};
-use murr::service::MurrService;
-use murr::testutil::{bench_column_names, bench_generate_keys, generate_batch};
+use murr::testutil::{bench_column_names, bench_generate_keys};
 
-const NUM_ROWS: usize = 10_000_000;
-const NUM_KEYS: usize = 1000;
-
-fn make_schema(col_names: &[String]) -> (TableSchema, Arc<Schema>) {
-    let mut columns = HashMap::new();
-    columns.insert(
-        "key".to_string(),
-        ColumnConfig {
-            dtype: DType::Utf8,
-            nullable: false,
-        },
-    );
-    let mut arrow_fields = vec![Field::new("key", DataType::Utf8, false)];
-
-    for name in col_names {
-        columns.insert(
-            name.clone(),
-            ColumnConfig {
-                dtype: DType::Float32,
-                nullable: false,
-            },
-        );
-        arrow_fields.push(Field::new(name, DataType::Float32, false));
-    }
-
-    let table_schema = TableSchema {
-        name: "bench".to_string(),
-        key: "key".to_string(),
-        columns,
-    };
-    let arrow_schema = Arc::new(Schema::new(arrow_fields));
-    (table_schema, arrow_schema)
-}
+mod benchutil;
+use benchutil::{NUM_KEYS, NUM_ROWS};
 
 fn bench_table_get(c: &mut Criterion) {
     let rt = Runtime::new().unwrap();
 
     let col_names = bench_column_names();
-    let (table_schema, arrow_schema) = make_schema(&col_names);
-
-    let dir = TempDir::new().unwrap();
-    let svc = Arc::new(MurrService::new(dir.path().to_path_buf()));
-
-    // Create table and write a single segment with 10M rows.
-    rt.block_on(async {
-        svc.create("bench", table_schema).await.unwrap();
-        let batch = generate_batch(&arrow_schema, NUM_ROWS);
-        svc.write("bench", &batch).await.unwrap();
-    });
+    let (_dir, svc) = benchutil::setup_service(&rt);
+    let svc = Arc::new(svc);
 
     let col_refs: Vec<&str> = col_names.iter().map(|s| s.as_str()).collect();
     let keys = bench_generate_keys(NUM_KEYS, NUM_ROWS);


### PR DESCRIPTION
  This branch adds Redis comparison benchmarks and refactors the existing benchmark infrastructure:                                                                                                               
                                                                                                                                                                                                                
#  New benchmarks
  - api_bench — Benchmarks Murr's HTTP API fetch endpoint (Arrow IPC response) using reqwest against a real Axum server on a random port. Fetches 1,000 keys from a 10M-row table.
  - redis_feast_bench — Benchmarks Redis using the Feast-style pattern: each key is a hash with per-column fields (HSET key col0 <bytes> col1 <bytes> ...), fetched via pipelined HGETALL. Uses testcontainers for
   Redis.
  - redis_featureblob_bench — Benchmarks Redis using a feature-blob pattern: each key stores a single binary blob of all column values (SET key <blob>), fetched via MGET. Uses testcontainers for Redis.

#  Refactoring:
  - Extracted shared benchmark setup (schema creation, service initialization, constants) into benches/benchutil.rs and refactored table_bench.rs to use it.

#  Dependencies:
  - Added reqwest (with JSON feature) as a dev dependency for the API benchmark.
