### PR TITLE
CI release: use proper artifact name on windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,13 @@ jobs:
         include:
           - os: ubuntu-22.04
             artifact: murr-linux-x64
+            binary: murr
           - os: macos-14
             artifact: murr-macos-arm64
+            binary: murr
           - os: windows-2022
             artifact: murr-windows-x64.exe
+            binary: murr.exe
     runs-on: ${{ matrix.os }}
     env:
       MACOSX_DEPLOYMENT_TARGET: "11.0"
@@ -41,7 +44,8 @@ jobs:
         run: cargo build --release
 
       - name: Prepare release artifact
-        run: cp target/release/murr ${{ matrix.artifact }}
+        shell: bash
+        run: cp target/release/${{ matrix.binary }} ${{ matrix.artifact }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
```
Run cp target/release/murr murr-windows-x64.exe
Copy-Item: D:\a\_temp\28fcb9c5-8a37-4e60-bd65-319b4537c3cc.ps1:2
Line |
   2 |  cp target/release/murr murr-windows-x64.exe
     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Cannot find path 'D:\a\murr\murr\target\release\murr' because it does not exist.
Error: Process completed with exit code 1.
```