### PR TITLE
fix benchmark warnings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,4 +117,4 @@ Supported dtypes: `utf8`, `int16`, `int32`, `int64`, `uint16`, `uint32`, `uint64
 - E2E API tests in `tests/api_test.rs` using `tower::ServiceExt::oneshot()` against the router (no TCP server needed)
 - Parameterized dtype tests using `rstest`
 - Test fixtures in `tests/fixtures/`
-- Benchmarks: `table_bench` (10M rows), `api_bench` (Murr vs Redis comparison via `testcontainers`), `hashmap_bench`, `hashmap_row_bench`
+- Benchmarks: `table_bench` (10M rows), `http_bench` and `flight_bench` (Murr HTTP/Flight vs Redis comparison via `testcontainers`), `hashmap_bench`, `hashmap_row_bench`, `redis_feast_bench`, `redis_featureblob_bench`

--- a/benches/benchutil.rs
+++ b/benches/benchutil.rs
@@ -12,6 +12,7 @@ use murr::testutil::{bench_column_names, generate_batch};
 pub const NUM_ROWS: usize = 10_000_000;
 pub const NUM_KEYS: usize = 1000;
 
+#[allow(dead_code)]
 pub fn make_schema(col_names: &[String]) -> (TableSchema, Arc<Schema>) {
     let mut columns = HashMap::new();
     columns.insert(
@@ -45,6 +46,7 @@ pub fn make_schema(col_names: &[String]) -> (TableSchema, Arc<Schema>) {
 
 /// Set up a MurrService with a "bench" table containing NUM_ROWS rows of Float32 data.
 /// Returns the TempDir (must be kept alive) and the service.
+#[allow(dead_code)]
 pub fn setup_service(rt: &Runtime) -> (TempDir, MurrService) {
     let col_names = bench_column_names();
     let (table_schema, arrow_schema) = make_schema(&col_names);

--- a/benches/hashmap_bench.rs
+++ b/benches/hashmap_bench.rs
@@ -6,9 +6,11 @@ use arrow::array::{Array, Float32Array};
 use arrow::buffer::{BooleanBuffer, Buffer, NullBuffer};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use rand::RngExt as _;
 use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
+use rand::SeedableRng;
+use std::hint::black_box;
 
 const NUM_ROWS: usize = 10_000_000;
 const NUM_COLUMNS: usize = 10;
@@ -95,7 +97,7 @@ impl SimpleTable {
 fn generate_keys(num_keys: usize, max_key: usize) -> Vec<String> {
     let mut rng = StdRng::seed_from_u64(RNG_SEED);
     (0..num_keys)
-        .map(|_| rng.gen_range(0..max_key).to_string())
+        .map(|_| rng.random_range(0..max_key).to_string())
         .collect()
 }
 

--- a/benches/hashmap_row_bench.rs
+++ b/benches/hashmap_row_bench.rs
@@ -6,9 +6,11 @@ use arrow::array::{Array, Float32Array};
 use arrow::buffer::{BooleanBuffer, Buffer, NullBuffer};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use rand::RngExt as _;
 use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
+use rand::SeedableRng;
+use std::hint::black_box;
 
 const NUM_ROWS: usize = 10_000_000;
 const NUM_COLUMNS: usize = 10;
@@ -204,7 +206,7 @@ impl ByteBlobTable {
 fn generate_keys(num_keys: usize, max_key: usize) -> Vec<String> {
     let mut rng = StdRng::seed_from_u64(RNG_SEED);
     (0..num_keys)
-        .map(|_| rng.gen_range(0..max_key).to_string())
+        .map(|_| rng.random_range(0..max_key).to_string())
         .collect()
 }
 
@@ -252,5 +254,5 @@ fn bench_hashmap_byte_blob_get(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_hashmap_byte_blob_get);
+criterion_group!(benches, bench_hashmap_row_get, bench_hashmap_byte_blob_get);
 criterion_main!(benches);

--- a/benches/http_bench.rs
+++ b/benches/http_bench.rs
@@ -3,7 +3,8 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use std::time::Duration;
 
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::hint::black_box;
 use serde_json::json;
 use murr::api::MurrHttpService;
 use murr::testutil::{bench_column_names, bench_generate_keys};

--- a/benches/redis_feast_bench.rs
+++ b/benches/redis_feast_bench.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::hint::black_box;
 use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::redis::{Redis, REDIS_PORT};
 use tokio::runtime::Runtime;
@@ -23,8 +24,8 @@ fn bench_redis_feast(c: &mut Criterion) {
         let host = container.get_host().await.unwrap();
         let port = container.get_host_port_ipv4(REDIS_PORT).await.unwrap();
         let client = redis::Client::open(format!("redis://{host}:{port}")).unwrap();
-        let con = client
-            .get_multiplexed_tokio_connection()
+        let con: redis::aio::MultiplexedConnection = client
+            .get_multiplexed_async_connection()
             .await
             .unwrap();
         (con, container)

--- a/benches/redis_featureblob_bench.rs
+++ b/benches/redis_featureblob_bench.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::hint::black_box;
 use redis::AsyncCommands;
 use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::redis::{Redis, REDIS_PORT};
@@ -22,8 +23,8 @@ fn bench_redis_featureblob(c: &mut Criterion) {
         let host = container.get_host().await.unwrap();
         let port = container.get_host_port_ipv4(REDIS_PORT).await.unwrap();
         let client = redis::Client::open(format!("redis://{host}:{port}")).unwrap();
-        let con = client
-            .get_multiplexed_tokio_connection()
+        let con: redis::aio::MultiplexedConnection = client
+            .get_multiplexed_async_connection()
             .await
             .unwrap();
         (con, container)

--- a/benches/table_bench.rs
+++ b/benches/table_bench.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::hint::black_box;
 use tokio::runtime::Runtime;
 
 use murr::testutil::{bench_column_names, bench_generate_keys};


### PR DESCRIPTION
#  Changes                                                                                                                                                                                                         
                                                                                                                                                                                                                  
  Benchmark warning fixes:                                                                                                                                                                                        
  - Replace deprecated criterion::black_box with std::hint::black_box across all benchmarks                                                                                                                     
  - Update rand API calls: gen_range → random_range, add RngExt trait import
  - Update redis async connection API: get_multiplexed_tokio_connection → get_multiplexed_async_connection
  - Add #[allow(dead_code)] to shared bench utilities (make_schema, setup_service) not used by every benchmark binary
  - Add #[global_allocator] mimalloc to flight_bench
  - Fix hashmap_row_bench to include missing bench_hashmap_row_get in its criterion group

  Documentation updates:
  - Document Arrow Flight gRPC API (port 8081) in README with RPC table and ticket format
  - Add Flight benchmark numbers to performance comparison table
  - Add Python Flight client usage example
  - Update performance claims (~2.5x faster than Redis MGET, ~36x faster than Feast)
  - Update benchmark list in both README.md and CLAUDE.md
