### PR TITLE
move all service to blocking thread pool

### DIFF
--- a/.memory/io_service_integration.md
+++ b/.memory/io_service_integration.md
@@ -24,17 +24,29 @@ Inner keys nest the corresponding RocksDB tunables. Specifying both is rejected 
 
 ```rust
 pub struct MurrService {
-    tables: tokio::sync::RwLock<HashMap<String, io::table::Table<RocksDBStore>>>,
+    tables: std::sync::RwLock<HashMap<String, io::table::Table<RocksDBStore>>>,
     store: Arc<std::sync::RwLock<RocksDBStore>>,
     config: Config,
 }
 ```
 
-One `Arc<StdRwLock<RocksDBStore>>` shared across all tables (one RocksDB DB, many CFs). Each table holds its own clone of the `Arc` and locks it internally per call.
+One `Arc<StdRwLock<RocksDBStore>>` shared across all tables (one RocksDB DB, many CFs). Each table holds its own clone of the `Arc` and locks it internally per call. The service's public methods (`new`, `create`, `write`, `read`, `list_tables`, `get_schema`) are all **sync**.
 
 **Why no `TableOps` trait, no `Box<dyn ...>`** — only one concrete backend exists (`RocksDBStore`), and `io::Table::read`/`write` already take `&self` (the store-level RwLock handles serialisation). Trait erasure plus `&mut self` would have forced HashMap-write-lock during writes; concrete `Table<RocksDBStore>` lets the HashMap stay at a read lock for both reads and writes, so writes on different tables run concurrently. Same-table serialisation comes from the store's internal RwLock.
 
-**Why `tokio::sync::RwLock` outside, `std::sync::RwLock` inside** — outer lock is contended only briefly (HashMap insert/lookup) but crosses `.await` boundaries; tokio version is the right choice. Inner lock wraps `RocksDBStore` whose ops are all sync — std lock is cheaper and `io::Table` already expects `Arc<RwLock<S>>` shape from `std`.
+**Why std::sync::RwLock both inside and outside** — the only async work in the service was the `.await` on the outer tables-registry lock, which guards a HashMap lookup. With RocksDB sync, the entire method body is CPU/blocking work; pretending it's async invited holding std locks across `.await` boundaries. The crossing point now lives one level up at the API handlers (see below).
+
+**Lock poisoning** — service methods recover via `unwrap_or_else(PoisonError::into_inner)` rather than `.expect()`. The inner HashMap can be inconsistent only if a panic landed mid-`insert`; for our use (insert-once + mostly reads) recovery is safe. Inside `io::Table` and `RocksDBStore` the existing pattern still uses `.expect("...lock poisoned")` — pre-existing, unchanged.
+
+## Async/sync boundary at API handlers
+
+HTTP handlers (`api/http/handlers.rs`), Flight RPCs (`api/flight/mod.rs`), and `PyMurrLocalAsync` all wrap service calls in `tokio::task::spawn_blocking(move || ...)`. The Arc-cloned `MurrService` and any owned arguments (`String`, `Vec<String>`, `Bytes`) move into the closure; `&str` slices are rebuilt inside. `JoinError`s (panic-only — the closure itself returns `Result<_, MurrError>`) map to `MurrError::IoError` → HTTP 500 / gRPC Internal.
+
+**Why `spawn_blocking` over `block_in_place`** — the blocking pool is demand-spawned up to 512 threads, so concurrency isn't capped at `worker_threads`. PlainTable+mmap reads are usually short, but cold-cache block reads can take ms; capping in-flight requests at core count would hurt tail latency. The ~1µs thread-hop is negligible against multi-key read cost.
+
+**Why fetch/write-table do their Arrow/Parquet encode/decode inside the closure** — that's CPU work too, and pulling it onto the blocking pool keeps the async runtime free. Only response wrapping (`Json`, `into_response`) stays async.
+
+**Why `PyMurrLocalSync` no longer needs an unconditional tokio Runtime** — without async data ops there's nothing to `block_on`. The Runtime is now `Option<Runtime>`, present only when `http_port` is set (the in-process HTTP server still needs a tokio handle to live on).
 
 **Why the empty-table read returns nulls instead of erroring** — missing-key semantics are uniform: any key the store doesn't have produces `None` in the read result, which the column encoder turns into a null row. A table with zero rows is just the all-keys-miss case. No special case for "table has no data."
 

--- a/benches/multi_segment_index_bench.rs
+++ b/benches/multi_segment_index_bench.rs
@@ -5,7 +5,6 @@ use std::time::Duration;
 use arrow::datatypes::Schema;
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use tempfile::TempDir;
-use tokio::runtime::Runtime;
 
 use murr::conf::{BackendConfig, Config, StorageConfig};
 use murr::core::{ColumnSchema, DType, TableSchema};
@@ -44,7 +43,6 @@ fn make_schema() -> (TableSchema, Arc<Schema>) {
 }
 
 fn bench_multi_segment_write(c: &mut Criterion) {
-    let rt = Runtime::new().unwrap();
     let (table_schema, arrow_schema) = make_schema();
     let batch = generate_batch(&arrow_schema, ROWS_PER_SEGMENT);
 
@@ -59,23 +57,21 @@ fn bench_multi_segment_write(c: &mut Criterion) {
             BenchmarkId::new("segments", num_segments),
             &num_segments,
             |b, &n| {
-                b.to_async(&rt).iter(|| {
+                b.iter(|| {
                     let schema = table_schema.clone();
                     let batch = batch.clone();
-                    async move {
-                        let dir = TempDir::new().unwrap();
-                        let config = Config {
-                            storage: StorageConfig {
-                                path: dir.path().to_path_buf(),
-                                backend: BackendConfig::Mmap(PlainConfig::default()),
-                            },
-                            ..Config::default()
-                        };
-                        let svc = MurrService::new(config).await.unwrap();
-                        svc.create("bench", schema).await.unwrap();
-                        for _ in 0..n {
-                            svc.write("bench", &batch).await.unwrap();
-                        }
+                    let dir = TempDir::new().unwrap();
+                    let config = Config {
+                        storage: StorageConfig {
+                            path: dir.path().to_path_buf(),
+                            backend: BackendConfig::Mmap(PlainConfig::default()),
+                        },
+                        ..Config::default()
+                    };
+                    let svc = MurrService::new(config).unwrap();
+                    svc.create("bench", schema).unwrap();
+                    for _ in 0..n {
+                        svc.write("bench", &batch).unwrap();
                     }
                 });
             },

--- a/python/src/async_client.rs
+++ b/python/src/async_client.rs
@@ -24,7 +24,10 @@ impl PyMurrLocalAsync {
     fn create(py: Python<'_>, cache_dir: String, http_port: Option<u16>) -> PyResult<Bound<'_, PyAny>> {
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let config = build_config(cache_dir, http_port);
-            let service = MurrService::new(config).await.map_err(into_py_err)?;
+            let service = tokio::task::spawn_blocking(move || MurrService::new(config))
+                .await
+                .map_err(join_to_py_err)?
+                .map_err(into_py_err)?;
             let service = Arc::new(service);
 
             if http_port.is_some() {
@@ -46,7 +49,10 @@ impl PyMurrLocalAsync {
         let service = self.service.clone();
         let schema = schema.0;
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            service.create(&name, schema).await.map_err(into_py_err)
+            tokio::task::spawn_blocking(move || service.create(&name, schema))
+                .await
+                .map_err(join_to_py_err)?
+                .map_err(into_py_err)
         })
     }
 
@@ -59,9 +65,9 @@ impl PyMurrLocalAsync {
         let batch = RecordBatch::from_pyarrow_bound(batch)?;
         let service = self.service.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            service
-                .write(&table_name, &batch)
+            tokio::task::spawn_blocking(move || service.write(&table_name, &batch))
                 .await
+                .map_err(join_to_py_err)?
                 .map_err(into_py_err)
         })
     }
@@ -75,13 +81,14 @@ impl PyMurrLocalAsync {
     ) -> PyResult<Bound<'py, PyAny>> {
         let service = self.service.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
-            let col_refs: Vec<&str> = columns.iter().map(|s| s.as_str()).collect();
-
-            let batch = service
-                .read(&table_name, &key_refs, &col_refs)
-                .await
-                .map_err(into_py_err)?;
+            let batch = tokio::task::spawn_blocking(move || {
+                let key_refs: Vec<&str> = keys.iter().map(String::as_str).collect();
+                let col_refs: Vec<&str> = columns.iter().map(String::as_str).collect();
+                service.read(&table_name, &key_refs, &col_refs)
+            })
+            .await
+            .map_err(join_to_py_err)?
+            .map_err(into_py_err)?;
 
             Python::try_attach(|py| batch.to_pyarrow(py).map(|b| b.unbind()))
                 .expect("GIL should be available")
@@ -91,7 +98,9 @@ impl PyMurrLocalAsync {
     fn list_tables<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let service = self.service.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let tables = service.list_tables().await;
+            let tables = tokio::task::spawn_blocking(move || service.list_tables())
+                .await
+                .map_err(join_to_py_err)?;
             let result: HashMap<String, PyTableSchema> = tables
                 .into_iter()
                 .map(|(name, schema)| (name, PyTableSchema(schema)))
@@ -107,11 +116,15 @@ impl PyMurrLocalAsync {
     ) -> PyResult<Bound<'py, PyAny>> {
         let service = self.service.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let schema = service
-                .get_schema(&table_name)
+            let schema = tokio::task::spawn_blocking(move || service.get_schema(&table_name))
                 .await
+                .map_err(join_to_py_err)?
                 .map_err(into_py_err)?;
             Ok(PyTableSchema(schema))
         })
     }
+}
+
+fn join_to_py_err(e: tokio::task::JoinError) -> PyErr {
+    pyo3::exceptions::PyRuntimeError::new_err(format!("blocking task failed: {e}"))
 }

--- a/python/src/sync_client.rs
+++ b/python/src/sync_client.rs
@@ -15,7 +15,8 @@ use crate::schema::PyTableSchema;
 #[pyclass(name = "MurrLocalSync")]
 pub struct PyMurrLocalSync {
     service: Arc<MurrService>,
-    runtime: tokio::runtime::Runtime,
+    // Present only when an HTTP server is running — it needs a tokio runtime to live on.
+    _runtime: Option<tokio::runtime::Runtime>,
 }
 
 #[pymethods]
@@ -23,36 +24,31 @@ impl PyMurrLocalSync {
     #[new]
     #[pyo3(signature = (cache_dir, http_port=None))]
     fn new(cache_dir: String, http_port: Option<u16>) -> PyResult<Self> {
-        let runtime = tokio::runtime::Runtime::new()
-            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
-
         let config = build_config(cache_dir, http_port);
+        let service = Arc::new(MurrService::new(config).map_err(into_py_err)?);
 
-        let service = runtime
-            .block_on(MurrService::new(config))
-            .map_err(into_py_err)?;
+        let runtime = if http_port.is_some() {
+            let rt = tokio::runtime::Runtime::new()
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+            spawn_http_server(&service, rt.handle());
+            Some(rt)
+        } else {
+            None
+        };
 
-        let service = Arc::new(service);
-
-        if http_port.is_some() {
-            spawn_http_server(&service, runtime.handle());
-        }
-
-        Ok(Self { service, runtime })
+        Ok(Self { service, _runtime: runtime })
     }
 
     fn create_table(&self, py: Python<'_>, name: String, schema: PyTableSchema) -> PyResult<()> {
         let service = self.service.clone();
         let schema = schema.0;
-        py.detach(|| self.runtime.block_on(service.create(&name, schema)))
-            .map_err(into_py_err)
+        py.detach(|| service.create(&name, schema)).map_err(into_py_err)
     }
 
     fn write(&self, py: Python<'_>, table_name: String, batch: &Bound<'_, PyAny>) -> PyResult<()> {
         let batch = RecordBatch::from_pyarrow_bound(batch)?;
         let service = self.service.clone();
-        py.detach(|| self.runtime.block_on(service.write(&table_name, &batch)))
-            .map_err(into_py_err)
+        py.detach(|| service.write(&table_name, &batch)).map_err(into_py_err)
     }
 
     fn read<'py>(
@@ -62,14 +58,12 @@ impl PyMurrLocalSync {
         keys: Vec<String>,
         columns: Vec<String>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
-        let col_refs: Vec<&str> = columns.iter().map(|s| s.as_str()).collect();
-
         let service = self.service.clone();
         let batch = py
             .detach(|| {
-                self.runtime
-                    .block_on(service.read(&table_name, &key_refs, &col_refs))
+                let key_refs: Vec<&str> = keys.iter().map(String::as_str).collect();
+                let col_refs: Vec<&str> = columns.iter().map(String::as_str).collect();
+                service.read(&table_name, &key_refs, &col_refs)
             })
             .map_err(into_py_err)?;
 
@@ -78,7 +72,7 @@ impl PyMurrLocalSync {
 
     fn list_tables(&self, py: Python<'_>) -> PyResult<HashMap<String, PyTableSchema>> {
         let service = self.service.clone();
-        let tables = py.detach(|| self.runtime.block_on(service.list_tables()));
+        let tables = py.detach(|| service.list_tables());
 
         Ok(tables
             .into_iter()
@@ -89,7 +83,7 @@ impl PyMurrLocalSync {
     fn get_schema(&self, py: Python<'_>, table_name: String) -> PyResult<PyTableSchema> {
         let service = self.service.clone();
         let schema = py
-            .detach(|| self.runtime.block_on(service.get_schema(&table_name)))
+            .detach(|| service.get_schema(&table_name))
             .map_err(into_py_err)?;
 
         Ok(PyTableSchema(schema))

--- a/src/api/flight/mod.rs
+++ b/src/api/flight/mod.rs
@@ -71,14 +71,15 @@ impl FlightService for MurrFlightService {
         let fetch: FetchTicket = serde_json::from_slice(&ticket.ticket)
             .map_err(|e| Status::invalid_argument(format!("invalid ticket JSON: {e}")))?;
 
-        let keys: Vec<&str> = fetch.keys.iter().map(|s| s.as_str()).collect();
-        let columns: Vec<&str> = fetch.columns.iter().map(|s| s.as_str()).collect();
-
-        let batch = self
-            .service
-            .read(&fetch.table, &keys, &columns)
-            .await
-            .map_err(Status::from)?;
+        let service = self.service.clone();
+        let batch = tokio::task::spawn_blocking(move || {
+            let keys: Vec<&str> = fetch.keys.iter().map(String::as_str).collect();
+            let columns: Vec<&str> = fetch.columns.iter().map(String::as_str).collect();
+            service.read(&fetch.table, &keys, &columns)
+        })
+        .await
+        .map_err(join_to_status)?
+        .map_err(Status::from)?;
 
         let stream = FlightDataEncoderBuilder::new()
             .build(stream::once(async { Ok(batch) }))
@@ -95,12 +96,13 @@ impl FlightService for MurrFlightService {
         let table_name = descriptor
             .path
             .first()
-            .ok_or_else(|| Status::invalid_argument("path must contain table name"))?;
+            .ok_or_else(|| Status::invalid_argument("path must contain table name"))?
+            .clone();
 
-        let schema = self
-            .service
-            .get_schema(table_name)
+        let service = self.service.clone();
+        let schema = tokio::task::spawn_blocking(move || service.get_schema(&table_name))
             .await
+            .map_err(join_to_status)?
             .map_err(Status::from)?;
         let arrow_schema: Schema = (&schema).into();
 
@@ -120,12 +122,13 @@ impl FlightService for MurrFlightService {
         let table_name = descriptor
             .path
             .first()
-            .ok_or_else(|| Status::invalid_argument("path must contain table name"))?;
+            .ok_or_else(|| Status::invalid_argument("path must contain table name"))?
+            .clone();
 
-        let schema = self
-            .service
-            .get_schema(table_name)
+        let service = self.service.clone();
+        let schema = tokio::task::spawn_blocking(move || service.get_schema(&table_name))
             .await
+            .map_err(join_to_status)?
             .map_err(Status::from)?;
         let arrow_schema: Schema = (&schema).into();
         let options = IpcWriteOptions::default();
@@ -140,7 +143,10 @@ impl FlightService for MurrFlightService {
         &self,
         _request: Request<Criteria>,
     ) -> Result<Response<Self::ListFlightsStream>, Status> {
-        let tables = self.service.list_tables().await;
+        let service = self.service.clone();
+        let tables = tokio::task::spawn_blocking(move || service.list_tables())
+            .await
+            .map_err(join_to_status)?;
         let infos: Vec<Result<FlightInfo, Status>> = tables
             .into_iter()
             .map(|(name, schema)| {
@@ -197,4 +203,8 @@ impl FlightService for MurrFlightService {
     ) -> Result<Response<Self::ListActionsStream>, Status> {
         Err(Status::unimplemented("list_actions not supported"))
     }
+}
+
+fn join_to_status(e: tokio::task::JoinError) -> Status {
+    Status::internal(format!("blocking task failed: {e}"))
 }

--- a/src/api/http/handlers.rs
+++ b/src/api/http/handlers.rs
@@ -36,15 +36,22 @@ pub async fn health() -> &'static str {
 
 pub async fn list_tables(
     State(service): State<Arc<MurrService>>,
-) -> impl IntoResponse {
-    Json(service.list_tables().await)
+) -> Result<Json<std::collections::HashMap<String, TableSchema>>, ApiError> {
+    let svc = service.clone();
+    let tables = tokio::task::spawn_blocking(move || svc.list_tables())
+        .await
+        .map_err(join_to_api_error)?;
+    Ok(Json(tables))
 }
 
 pub async fn get_schema(
     State(service): State<Arc<MurrService>>,
     Path(name): Path<String>,
 ) -> Result<Json<TableSchema>, ApiError> {
-    let schema = service.get_schema(&name).await?;
+    let svc = service.clone();
+    let schema = tokio::task::spawn_blocking(move || svc.get_schema(&name))
+        .await
+        .map_err(join_to_api_error)??;
     Ok(Json(schema))
 }
 
@@ -53,7 +60,10 @@ pub async fn create_table(
     Path(name): Path<String>,
     Json(schema): Json<TableSchema>,
 ) -> Result<StatusCode, ApiError> {
-    service.create(&name, schema).await?;
+    let svc = service.clone();
+    tokio::task::spawn_blocking(move || svc.create(&name, schema))
+        .await
+        .map_err(join_to_api_error)??;
     Ok(StatusCode::CREATED)
 }
 
@@ -69,29 +79,33 @@ pub async fn fetch(
     headers: HeaderMap,
     Json(req): Json<FetchRequest>,
 ) -> Result<Response, ApiError> {
-    let keys: Vec<&str> = req.keys.iter().map(|s| s.as_str()).collect();
-    let columns: Vec<&str> = req.columns.iter().map(|s| s.as_str()).collect();
-
-    let batch = service.read(&name, &keys, &columns).await?;
-
     let wants_arrow = headers
         .get("accept")
         .and_then(|v| v.to_str().ok())
         .is_some_and(|v| v.contains(ARROW_IPC_MIME));
 
-    if wants_arrow {
-        let mut buf = Vec::new();
-        {
-            let mut writer = StreamWriter::try_new(&mut buf, &batch.schema())
-                .map_err(|e| ApiError(e.into()))?;
-            writer.write(&batch).map_err(|e| ApiError(e.into()))?;
-            writer.finish().map_err(|e| ApiError(e.into()))?;
+    let svc = service.clone();
+    tokio::task::spawn_blocking(move || -> Result<Response, ApiError> {
+        let keys: Vec<&str> = req.keys.iter().map(String::as_str).collect();
+        let columns: Vec<&str> = req.columns.iter().map(String::as_str).collect();
+        let batch = svc.read(&name, &keys, &columns)?;
+
+        if wants_arrow {
+            let mut buf = Vec::new();
+            {
+                let mut writer = StreamWriter::try_new(&mut buf, &batch.schema())
+                    .map_err(|e| ApiError(e.into()))?;
+                writer.write(&batch).map_err(|e| ApiError(e.into()))?;
+                writer.finish().map_err(|e| ApiError(e.into()))?;
+            }
+            Ok(([(axum::http::header::CONTENT_TYPE, ARROW_IPC_MIME)], buf).into_response())
+        } else {
+            let FetchResponse(json) = FetchResponse::try_from(&batch).map_err(ApiError)?;
+            Ok(Json(json).into_response())
         }
-        Ok(([(axum::http::header::CONTENT_TYPE, ARROW_IPC_MIME)], buf).into_response())
-    } else {
-        let FetchResponse(json) = FetchResponse::try_from(&batch).map_err(ApiError)?;
-        Ok(Json(json).into_response())
-    }
+    })
+    .await
+    .map_err(join_to_api_error)?
 }
 
 pub async fn write_table(
@@ -103,36 +117,46 @@ pub async fn write_table(
     let content_type = headers
         .get("content-type")
         .and_then(|v| v.to_str().ok())
-        .unwrap_or("");
+        .unwrap_or("")
+        .to_string();
 
-    let batch = if content_type.contains(ARROW_IPC_MIME) {
-        let cursor = Cursor::new(&body);
-        let mut reader = StreamReader::try_new(cursor, None)
-            .map_err(|e| ApiError(e.into()))?;
-        reader
-            .next()
-            .ok_or_else(|| ApiError(MurrError::TableError("empty Arrow IPC stream".into())))?
+    let svc = service.clone();
+    tokio::task::spawn_blocking(move || -> Result<StatusCode, ApiError> {
+        let batch = if content_type.contains(ARROW_IPC_MIME) {
+            let cursor = Cursor::new(&body);
+            let mut reader = StreamReader::try_new(cursor, None)
+                .map_err(|e| ApiError(e.into()))?;
+            reader
+                .next()
+                .ok_or_else(|| ApiError(MurrError::TableError("empty Arrow IPC stream".into())))?
+                .map_err(|e| ApiError(e.into()))?
+        } else if content_type.contains(PARQUET_MIME) {
+            let reader = ParquetRecordBatchReaderBuilder::try_new(body)
+                .map_err(|e| ApiError(MurrError::TableError(format!("invalid Parquet: {e}"))))?
+                .build()
+                .map_err(|e| ApiError(MurrError::TableError(format!("invalid Parquet: {e}"))))?;
+            let batches: Vec<_> = reader
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| ApiError(e.into()))?;
+            arrow::compute::concat_batches(
+                &batches[0].schema(),
+                &batches,
+            )
             .map_err(|e| ApiError(e.into()))?
-    } else if content_type.contains(PARQUET_MIME) {
-        let reader = ParquetRecordBatchReaderBuilder::try_new(body)
-            .map_err(|e| ApiError(MurrError::TableError(format!("invalid Parquet: {e}"))))?
-            .build()
-            .map_err(|e| ApiError(MurrError::TableError(format!("invalid Parquet: {e}"))))?;
-        let batches: Vec<_> = reader
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| ApiError(e.into()))?;
-        arrow::compute::concat_batches(
-            &batches[0].schema(),
-            &batches,
-        )
-        .map_err(|e| ApiError(e.into()))?
-    } else {
-        let write: WriteRequest = serde_json::from_slice(&body)
-            .map_err(|e| ApiError(MurrError::TableError(format!("invalid JSON: {e}"))))?;
-        let schema = service.get_schema(&name).await?;
-        write.into_record_batch(&schema).map_err(ApiError)?
-    };
+        } else {
+            let write: WriteRequest = serde_json::from_slice(&body)
+                .map_err(|e| ApiError(MurrError::TableError(format!("invalid JSON: {e}"))))?;
+            let schema = svc.get_schema(&name)?;
+            write.into_record_batch(&schema).map_err(ApiError)?
+        };
 
-    service.write(&name, &batch).await?;
-    Ok(StatusCode::OK)
+        svc.write(&name, &batch)?;
+        Ok(StatusCode::OK)
+    })
+    .await
+    .map_err(join_to_api_error)?
+}
+
+fn join_to_api_error(e: tokio::task::JoinError) -> ApiError {
+    ApiError(MurrError::IoError(format!("blocking task failed: {e}")))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,11 +26,7 @@ async fn main() {
     info!("Starting murr with config: {config:?}");
     info!("{ASCII_LOGO}");
 
-    let service = Arc::new(
-        MurrService::new(config)
-            .await
-            .expect("failed to load tables"),
-    );
+    let service = Arc::new(MurrService::new(config).expect("failed to load tables"));
 
     let http = MurrHttpService::new(service.clone());
     let flight = MurrFlightService::new(service.clone());

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,9 +1,8 @@
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock as StdRwLock};
+use std::sync::{Arc, PoisonError, RwLock};
 
 use arrow::record_batch::RecordBatch;
 use log::{info, warn};
-use tokio::sync::RwLock;
 
 use crate::conf::{BackendConfig, Config};
 use crate::core::{MurrError, TableSchema};
@@ -13,12 +12,12 @@ use crate::io::table::Table;
 
 pub struct MurrService {
     tables: RwLock<HashMap<String, Table<RocksDBStore>>>,
-    store: Arc<StdRwLock<RocksDBStore>>,
+    store: Arc<RwLock<RocksDBStore>>,
     config: Config,
 }
 
 impl MurrService {
-    pub async fn new(config: Config) -> Result<Self, MurrError> {
+    pub fn new(config: Config) -> Result<Self, MurrError> {
         std::fs::create_dir_all(&config.storage.path).map_err(|e| {
             MurrError::IoError(format!(
                 "creating storage path {}: {e}",
@@ -34,10 +33,10 @@ impl MurrService {
                 RocksDBStore::open_block(&config.storage.path, block)?
             }
         };
-        let store = Arc::new(StdRwLock::new(store));
+        let store = Arc::new(RwLock::new(store));
 
         let snapshot: Vec<(String, TableSchema)> = {
-            let s = store.read().expect("store lock poisoned");
+            let s = store.read().unwrap_or_else(PoisonError::into_inner);
             s.manifest()
                 .tables
                 .iter()
@@ -67,8 +66,8 @@ impl MurrService {
         &self.config
     }
 
-    pub async fn create(&self, table_name: &str, schema: TableSchema) -> Result<(), MurrError> {
-        let mut tables = self.tables.write().await;
+    pub fn create(&self, table_name: &str, schema: TableSchema) -> Result<(), MurrError> {
+        let mut tables = self.tables.write().unwrap_or_else(PoisonError::into_inner);
         if tables.contains_key(table_name) {
             return Err(MurrError::TableAlreadyExists(table_name.to_string()));
         }
@@ -77,34 +76,34 @@ impl MurrService {
         Ok(())
     }
 
-    pub async fn write(&self, table_name: &str, batch: &RecordBatch) -> Result<(), MurrError> {
-        let tables = self.tables.read().await;
+    pub fn write(&self, table_name: &str, batch: &RecordBatch) -> Result<(), MurrError> {
+        let tables = self.tables.read().unwrap_or_else(PoisonError::into_inner);
         let table = tables
             .get(table_name)
             .ok_or_else(|| MurrError::TableNotFound(table_name.to_string()))?;
         table.write(batch)
     }
 
-    pub async fn list_tables(&self) -> HashMap<String, TableSchema> {
-        let tables = self.tables.read().await;
+    pub fn list_tables(&self) -> HashMap<String, TableSchema> {
+        let tables = self.tables.read().unwrap_or_else(PoisonError::into_inner);
         tables.iter().map(|(k, v)| (k.clone(), v.schema().clone())).collect()
     }
 
-    pub async fn get_schema(&self, table_name: &str) -> Result<TableSchema, MurrError> {
-        let tables = self.tables.read().await;
+    pub fn get_schema(&self, table_name: &str) -> Result<TableSchema, MurrError> {
+        let tables = self.tables.read().unwrap_or_else(PoisonError::into_inner);
         let table = tables
             .get(table_name)
             .ok_or_else(|| MurrError::TableNotFound(table_name.to_string()))?;
         Ok(table.schema().clone())
     }
 
-    pub async fn read(
+    pub fn read(
         &self,
         table_name: &str,
         keys: &[&str],
         columns: &[&str],
     ) -> Result<RecordBatch, MurrError> {
-        let tables = self.tables.read().await;
+        let tables = self.tables.read().unwrap_or_else(PoisonError::into_inner);
         let table = tables
             .get(table_name)
             .ok_or_else(|| MurrError::TableNotFound(table_name.to_string()))?;
@@ -160,17 +159,17 @@ mod tests {
         .unwrap()
     }
 
-    #[tokio::test]
-    async fn test_create_write_read_round_trip() {
+    #[test]
+    fn test_create_write_read_round_trip() {
         let dir = TempDir::new().unwrap();
-        let svc = MurrService::new(test_config(&dir)).await.unwrap();
+        let svc = MurrService::new(test_config(&dir)).unwrap();
 
-        svc.create("users", test_schema()).await.unwrap();
+        svc.create("users", test_schema()).unwrap();
 
         let batch = test_batch(&["a", "b", "c"], &[1.0, 2.0, 3.0]);
-        svc.write("users", &batch).await.unwrap();
+        svc.write("users", &batch).unwrap();
 
-        let result = svc.read("users", &["c", "a"], &["score"]).await.unwrap();
+        let result = svc.read("users", &["c", "a"], &["score"]).unwrap();
         assert_eq!(result.num_rows(), 2);
 
         let vals = result
@@ -182,32 +181,32 @@ mod tests {
         assert_eq!(vals.value(1), 1.0);
     }
 
-    #[tokio::test]
-    async fn test_create_duplicate_errors() {
+    #[test]
+    fn test_create_duplicate_errors() {
         let dir = TempDir::new().unwrap();
-        let svc = MurrService::new(test_config(&dir)).await.unwrap();
+        let svc = MurrService::new(test_config(&dir)).unwrap();
 
-        svc.create("t", test_schema()).await.unwrap();
-        let err = svc.create("t", test_schema()).await;
+        svc.create("t", test_schema()).unwrap();
+        let err = svc.create("t", test_schema());
         assert!(err.is_err());
     }
 
-    #[tokio::test]
-    async fn test_read_nonexistent_table_errors() {
+    #[test]
+    fn test_read_nonexistent_table_errors() {
         let dir = TempDir::new().unwrap();
-        let svc = MurrService::new(test_config(&dir)).await.unwrap();
+        let svc = MurrService::new(test_config(&dir)).unwrap();
 
-        let err = svc.read("nope", &["a"], &["score"]).await;
+        let err = svc.read("nope", &["a"], &["score"]);
         assert!(err.is_err());
     }
 
-    #[tokio::test]
-    async fn test_read_empty_table_returns_nulls() {
+    #[test]
+    fn test_read_empty_table_returns_nulls() {
         let dir = TempDir::new().unwrap();
-        let svc = MurrService::new(test_config(&dir)).await.unwrap();
+        let svc = MurrService::new(test_config(&dir)).unwrap();
 
-        svc.create("empty", test_schema()).await.unwrap();
-        let result = svc.read("empty", &["a"], &["score"]).await.unwrap();
+        svc.create("empty", test_schema()).unwrap();
+        let result = svc.read("empty", &["a"], &["score"]).unwrap();
         assert_eq!(result.num_rows(), 1);
         let vals = result
             .column(0)
@@ -217,20 +216,20 @@ mod tests {
         assert!(vals.is_null(0));
     }
 
-    #[tokio::test]
-    async fn test_multiple_writes_accumulate() {
+    #[test]
+    fn test_multiple_writes_accumulate() {
         let dir = TempDir::new().unwrap();
-        let svc = MurrService::new(test_config(&dir)).await.unwrap();
+        let svc = MurrService::new(test_config(&dir)).unwrap();
 
-        svc.create("t", test_schema()).await.unwrap();
+        svc.create("t", test_schema()).unwrap();
 
         let batch1 = test_batch(&["a", "b"], &[1.0, 2.0]);
-        svc.write("t", &batch1).await.unwrap();
+        svc.write("t", &batch1).unwrap();
 
         let batch2 = test_batch(&["c"], &[3.0]);
-        svc.write("t", &batch2).await.unwrap();
+        svc.write("t", &batch2).unwrap();
 
-        let result = svc.read("t", &["a", "b", "c"], &["score"]).await.unwrap();
+        let result = svc.read("t", &["a", "b", "c"], &["score"]).unwrap();
         assert_eq!(result.num_rows(), 3);
 
         let vals = result
@@ -243,22 +242,22 @@ mod tests {
         assert_eq!(vals.value(2), 3.0);
     }
 
-    #[tokio::test]
-    async fn test_loads_existing_tables_on_startup() {
+    #[test]
+    fn test_loads_existing_tables_on_startup() {
         let dir = TempDir::new().unwrap();
 
         {
-            let svc = MurrService::new(test_config(&dir)).await.unwrap();
-            svc.create("users", test_schema()).await.unwrap();
+            let svc = MurrService::new(test_config(&dir)).unwrap();
+            svc.create("users", test_schema()).unwrap();
             let batch = test_batch(&["a", "b", "c"], &[1.0, 2.0, 3.0]);
-            svc.write("users", &batch).await.unwrap();
+            svc.write("users", &batch).unwrap();
         }
 
-        let svc = MurrService::new(test_config(&dir)).await.unwrap();
-        let tables = svc.list_tables().await;
+        let svc = MurrService::new(test_config(&dir)).unwrap();
+        let tables = svc.list_tables();
         assert!(tables.contains_key("users"));
 
-        let result = svc.read("users", &["c", "a"], &["score"]).await.unwrap();
+        let result = svc.read("users", &["c", "a"], &["score"]).unwrap();
         assert_eq!(result.num_rows(), 2);
 
         let vals = result
@@ -270,20 +269,20 @@ mod tests {
         assert_eq!(vals.value(1), 1.0);
     }
 
-    #[tokio::test]
-    async fn test_loads_empty_table_on_startup() {
+    #[test]
+    fn test_loads_empty_table_on_startup() {
         let dir = TempDir::new().unwrap();
 
         {
-            let svc = MurrService::new(test_config(&dir)).await.unwrap();
-            svc.create("empty", test_schema()).await.unwrap();
+            let svc = MurrService::new(test_config(&dir)).unwrap();
+            svc.create("empty", test_schema()).unwrap();
         }
 
-        let svc = MurrService::new(test_config(&dir)).await.unwrap();
-        let tables = svc.list_tables().await;
+        let svc = MurrService::new(test_config(&dir)).unwrap();
+        let tables = svc.list_tables();
         assert!(tables.contains_key("empty"));
 
-        let result = svc.read("empty", &["a"], &["score"]).await.unwrap();
+        let result = svc.read("empty", &["a"], &["score"]).unwrap();
         assert_eq!(result.num_rows(), 1);
         let vals = result
             .column(0)

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -29,7 +29,7 @@ async fn setup() -> (TempDir, Router) {
         },
         ..Config::default()
     };
-    let service = Arc::new(MurrService::new(config).await.unwrap());
+    let service = Arc::new(MurrService::new(config).unwrap());
     let api = MurrHttpService::new(service);
     let router = api.router();
     (dir, router)

--- a/tests/flight_test.rs
+++ b/tests/flight_test.rs
@@ -37,7 +37,7 @@ async fn setup() -> TestHarness {
         },
         ..Config::default()
     };
-    let service = Arc::new(MurrService::new(config).await.unwrap());
+    let service = Arc::new(MurrService::new(config).unwrap());
 
     // Create and populate a table
     let schema = TableSchema {
@@ -59,7 +59,7 @@ async fn setup() -> TestHarness {
             ),
         ]),
     };
-    service.create("features", schema).await.unwrap();
+    service.create("features", schema).unwrap();
 
     let arrow_schema = Arc::new(Schema::new(vec![
         Field::new("id", DataType::Utf8, false),
@@ -69,7 +69,7 @@ async fn setup() -> TestHarness {
     let scores: Float32Array = vec![Some(1.0), Some(2.0), None].into_iter().collect();
     let batch =
         RecordBatch::try_new(arrow_schema, vec![Arc::new(ids), Arc::new(scores)]).unwrap();
-    service.write("features", &batch).await.unwrap();
+    service.write("features", &batch).unwrap();
 
     // Start Flight server on OS-assigned port with shutdown signal
     let flight_svc = murr::api::MurrFlightService::new(service);


### PR DESCRIPTION
RocksDB is sync, so `MurrService` no longer pretends to be async. `new`/`create`/`write`/`read`/`list_tables`/`get_schema` drop the `async` qualifier, and the tables registry switches from                 `tokio::sync::RwLock` to `std::sync::RwLock` — there's nothing left to `.await` on inside the service.
                                                                                                                                                                                                                  
  The async/sync hop now lives at the API boundary instead:                                                                                                                                                       
                                                                                                                                                                                                                  
  - `api/http/handlers.rs` and `api/flight/mod.rs` wrap each service call in `tokio::task::spawn_blocking`. For `fetch` and `write_table` the Arrow/Parquet encode/decode moves into the closure too — same          reason, it's CPU work and shouldn't hold a tokio worker.                                                                                                                                                        
  - `PyMurrLocalAsync` does the same inside `future_into_py`.                                                                                                                                                     
  - `PyMurrLocalSync` no longer needs an unconditional tokio `Runtime` — it only allocates one when an in-process HTTP server is requested.                                                                       
                                                                                                                                                                                                                  
  Picked `spawn_blocking` over `block_in_place` so concurrency isn't capped at `worker_threads`; the blocking pool scales up to 512 on demand and the ~1µs thread-hop is noise next to a multi-key RocksDB read.  

  No behavioural change at the wire level. All 96 tests pass; `MurrService::new` panic-safety on partial CF load is preserved.