### PR TITLE
CI: remove debuginfo from rocksdb dev build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,9 @@ harness = false
 name = "row_vs_col_bench"
 harness = false
 
+[profile.dev.package.librocksdb-sys]
+debug = "line-tables-only"
+
 [profile.bench]
 debug = 1         # line tables + symbols (good enough for perf)
 lto = false       # optional: makes disasm easier to read


### PR DESCRIPTION
Attempting to trim down the CI cache size. Rocksdb debug build is 1GB omg