### PR TITLE
ci: only run tests on dev build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
 
       - name: Run tests
         run: |
-          cargo check --all-targets
           cargo test
 
   python-test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,9 +75,6 @@ jobs:
         with:
           shared-key: "release-${{ matrix.os }}"
 
-      - name: Run tests
-        run: cargo test
-
       - name: Build release binary
         run: cargo build --release
 


### PR DESCRIPTION
as cargo check compiles rocksdb twice otherwise :(