### PR TITLE
Rocksdb read method

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ The project uses .memory directory as an append-only log of architectural decisi
 * after you finish implementing a big feature (e.g. using a plan mode), write a 2-3 paragraph comment explaining the reasoning.
 * the comment should be in raw markdown so I can copy-paste it as is. do not over-use formatting.
 * do not go too deep on implementation details, focus on why things were changed and user-visible changes.
-* prefer human language, no AI slop please.
+* prefer human language, no AI slop please. Also do not use em-dashes.
 
 ### Build notes
 

--- a/src/io/store/rocksdb/block.rs
+++ b/src/io/store/rocksdb/block.rs
@@ -1,6 +1,7 @@
 use rocksdb::{BlockBasedOptions, Cache, DataBlockIndexType, Options};
 use serde::{Deserialize, Serialize};
 
+use crate::io::store::rocksdb::ReadMethod;
 use crate::io::store::rocksdb::plain::{
     default_data_block_hash_ratio, default_disable_auto_compactions,
     default_target_file_size_base, default_write_buffer_size,
@@ -44,6 +45,8 @@ pub struct BlockConfig {
     pub target_file_size_base: u64,
     #[serde(default = "default_disable_auto_compactions")]
     pub disable_auto_compactions: bool,
+    #[serde(default = "default_block_read_method")]
+    pub read_method: ReadMethod,
 }
 
 impl Default for BlockConfig {
@@ -65,8 +68,13 @@ impl Default for BlockConfig {
             write_buffer_size: default_write_buffer_size(),
             target_file_size_base: default_target_file_size_base(),
             disable_auto_compactions: default_disable_auto_compactions(),
+            read_method: default_block_read_method(),
         }
     }
+}
+
+fn default_block_read_method() -> ReadMethod {
+    ReadMethod::MultiGetSorted
 }
 
 fn default_true() -> bool {

--- a/src/io/store/rocksdb/mod.rs
+++ b/src/io/store/rocksdb/mod.rs
@@ -1,7 +1,8 @@
 use std::path::{Path, PathBuf};
 
 use arrow::array::RecordBatch;
-use rocksdb::{DB, Options, ReadOptions, WriteBatch, WriteOptions};
+use rocksdb::{ColumnFamily, DB, DBPinnableSlice, Options, ReadOptions, WriteBatch, WriteOptions};
+use serde::{Deserialize, Serialize};
 
 use crate::core::{MurrError, TableSchema};
 use crate::io::row::read::ReadBatchBuilder;
@@ -14,6 +15,14 @@ pub mod plain;
 
 const MANIFEST_FILE: &str = "manifest.json";
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReadMethod {
+    MultiGet,
+    MultiGetSorted,
+    Get,
+}
+
 pub struct RocksDBStore {
     db: DB,
     cf_opts: Options,
@@ -22,7 +31,7 @@ pub struct RocksDBStore {
     path: PathBuf,
     manifest: Manifest,
     write_buffer_size: usize,
-    sort_keys: bool,
+    read_method: ReadMethod,
 }
 
 impl RocksDBStore {
@@ -33,7 +42,7 @@ impl RocksDBStore {
             cf_opts,
             ReadOptions::default(),
             config.write_buffer_size,
-            false,
+            config.read_method,
         )
     }
 
@@ -47,7 +56,7 @@ impl RocksDBStore {
             cf_opts,
             read_opts,
             config.write_buffer_size,
-            true,
+            config.read_method,
         )
     }
 
@@ -56,7 +65,7 @@ impl RocksDBStore {
         cf_opts: Options,
         read_opts: ReadOptions,
         write_buffer_size: usize,
-        sort_keys: bool,
+        read_method: ReadMethod,
     ) -> Result<Self, MurrError> {
         let cfs = DB::list_cf(&cf_opts, path).unwrap_or_default();
         let cf_descriptors = cfs.iter().map(|name| (name.as_str(), cf_opts.clone()));
@@ -70,12 +79,56 @@ impl RocksDBStore {
             path: path.to_path_buf(),
             manifest,
             write_buffer_size,
-            sort_keys,
+            read_method,
         })
     }
 
     fn manifest_path(&self) -> PathBuf {
         self.path.join(MANIFEST_FILE)
+    }
+
+    fn read_multiget<'a>(
+        &'a self,
+        cf: &ColumnFamily,
+        keys: &[&[u8]],
+    ) -> Vec<Result<Option<DBPinnableSlice<'a>>, rocksdb::Error>> {
+        self.db
+            .batched_multi_get_cf_opt(cf, keys, false, &self.read_opts)
+    }
+
+    fn read_multiget_sorted<'a>(
+        &'a self,
+        cf: &ColumnFamily,
+        keys: &[&[u8]],
+    ) -> Vec<Result<Option<DBPinnableSlice<'a>>, rocksdb::Error>> {
+        let n = keys.len();
+        let mut order: Vec<usize> = (0..n).collect();
+        order.sort_unstable_by_key(|&i| keys[i]);
+        let sorted: Vec<&[u8]> = order.iter().map(|&i| keys[i]).collect();
+        let mut raw = self
+            .db
+            .batched_multi_get_cf_opt(cf, &sorted, true, &self.read_opts);
+        // raw[i] is the result for keys[order[i]]; move each raw[i] to position order[i]
+        // via cycle-following. Each inner iteration fixes one slot permanently, so total
+        // work is O(n) swaps even though the loop is nested.
+        for i in 0..n {
+            while order[i] != i {
+                let t = order[i];
+                raw.swap(i, t);
+                order.swap(i, t);
+            }
+        }
+        raw
+    }
+
+    fn read_get<'a>(
+        &'a self,
+        cf: &ColumnFamily,
+        keys: &[&[u8]],
+    ) -> Vec<Result<Option<DBPinnableSlice<'a>>, rocksdb::Error>> {
+        keys.iter()
+            .map(|k| self.db.get_pinned_cf_opt(cf, k, &self.read_opts))
+            .collect()
     }
 }
 
@@ -123,28 +176,10 @@ impl Store for RocksDBStore {
             .cf_handle(table)
             .ok_or_else(|| MurrError::TableNotFound(table.to_string()))?;
 
-        let raw = if self.sort_keys {
-            let n = keys.len();
-            let mut order: Vec<usize> = (0..n).collect();
-            order.sort_unstable_by_key(|&i| keys[i]);
-            let sorted: Vec<&[u8]> = order.iter().map(|&i| keys[i]).collect();
-            let mut raw = self
-                .db
-                .batched_multi_get_cf_opt(&cf, &sorted, true, &self.read_opts);
-            // raw[i] is the result for keys[order[i]]; move each raw[i] to position order[i]
-            // via cycle-following. Each inner iteration fixes one slot permanently, so total
-            // work is O(n) swaps even though the loop is nested.
-            for i in 0..n {
-                while order[i] != i {
-                    let t = order[i];
-                    raw.swap(i, t);
-                    order.swap(i, t);
-                }
-            }
-            raw
-        } else {
-            self.db
-                .batched_multi_get_cf_opt(&cf, keys, false, &self.read_opts)
+        let raw = match self.read_method {
+            ReadMethod::MultiGet => self.read_multiget(cf, keys),
+            ReadMethod::MultiGetSorted => self.read_multiget_sorted(cf, keys),
+            ReadMethod::Get => self.read_get(cf, keys),
         };
         for r in &raw {
             match r {
@@ -208,9 +243,16 @@ mod tests {
         }
     }
 
+    fn open_block_get(path: &Path) -> RocksDBStore {
+        let mut store = open_block(path);
+        store.read_method = ReadMethod::Get;
+        store
+    }
+
     #[rstest]
     #[case::plain(open_plain)]
     #[case::block(open_block)]
+    #[case::block_get(open_block_get)]
     fn round_trip(#[case] open: Opener) {
         let dir = TempDir::new().unwrap();
         let mut store = open(dir.path());
@@ -237,6 +279,7 @@ mod tests {
     #[rstest]
     #[case::plain(open_plain)]
     #[case::block(open_block)]
+    #[case::block_get(open_block_get)]
     fn read_preserves_caller_key_order(#[case] open: Opener) {
         let dir = TempDir::new().unwrap();
         let mut store = open(dir.path());
@@ -262,6 +305,7 @@ mod tests {
     #[rstest]
     #[case::plain(open_plain)]
     #[case::block(open_block)]
+    #[case::block_get(open_block_get)]
     fn missing_key_yields_none(#[case] open: Opener) {
         let dir = TempDir::new().unwrap();
         let mut store = open(dir.path());

--- a/src/io/store/rocksdb/plain.rs
+++ b/src/io/store/rocksdb/plain.rs
@@ -3,6 +3,8 @@ use rocksdb::{
 };
 use serde::{Deserialize, Serialize};
 
+use crate::io::store::rocksdb::ReadMethod;
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct PlainConfig {
     #[serde(default = "default_bloom_bits")]
@@ -24,6 +26,8 @@ pub struct PlainConfig {
     pub target_file_size_base: u64,
     #[serde(default = "default_disable_auto_compactions")]
     pub disable_auto_compactions: bool,
+    #[serde(default = "default_plain_read_method")]
+    pub read_method: ReadMethod,
 }
 
 impl Default for PlainConfig {
@@ -37,8 +41,13 @@ impl Default for PlainConfig {
             write_buffer_size: default_write_buffer_size(),
             target_file_size_base: default_target_file_size_base(),
             disable_auto_compactions: default_disable_auto_compactions(),
+            read_method: default_plain_read_method(),
         }
     }
+}
+
+fn default_plain_read_method() -> ReadMethod {
+    ReadMethod::MultiGet
 }
 
 fn default_bloom_bits() -> i32 {


### PR DESCRIPTION
Refactors the `RocksDBStore` read path:
  
  - Replaces the `sort_keys: bool` flag with a `ReadMethod` enum (`MultiGet`, `MultiGetSorted`, `Get`).
  - Lifts each strategy into its own helper that returns raw `Vec<Result<Option<DBPinnableSlice>>>`; `read` itself is now a thin dispatcher feeding results into the existing batch builder.
  - Adds a new `Get` strategy that calls `get_pinned_cf` in a loop, useful for small batches or A/B comparisons against multi-get.

  Why this matters:

  - The old bool was doing two jobs (picking the strategy and deciding whether to sort/unscramble), and there was no clean place to add a third option.
  - Splitting the sort/unscramble logic out of the main branch makes the caller-key-order invariant easier to reason about.
