### PR TITLE
CI: also run builds on master so we can reuse caches in branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
     branches: [master]
+  push:
+    branches: [master]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Otherwise GHA cache scoping rules do not allow cache reuse between branches.