### PR TITLE
Implement Get/ParGet concurrent reads with Rayon

### DIFF
--- a/.memory/io_rocksdb_store.md
+++ b/.memory/io_rocksdb_store.md
@@ -54,6 +54,16 @@ Only the rocksdb lookup phase is parallelized — the downstream `for r in &raw 
 
 `DBPinnableSlice<'_>`, `&DB`, `&ColumnFamily`, `&ReadOptions` are all `Send + Sync` in rocksdb-0.24 — no wrapping or `unsafe` is needed to share them across rayon workers.
 
+## Why `ReadMethod::ParMultiGet` exists alongside `ParGet`
+
+`ParGet` fans out one `get_pinned_cf_opt` per key across rayon workers — full parallelism, but every key pays the full point-lookup setup cost. `ParMultiGet` splits the input into `rayon::current_num_threads()` contiguous chunks and calls `batched_multi_get_cf_opt(..., sorted_input = false, ...)` once per chunk in parallel. Each chunk thus amortizes the rocksdb MultiGet path's per-call setup across ~`n / num_threads` keys.
+
+The fan-out uses `par_chunks(chunk_size).flat_map_iter(|chunk| batched_multi_get_cf_opt(...))`. `par_chunks` yields contiguous slices in input order; the indexed parallel iterator + `flat_map_iter` concatenates per-chunk result vectors in that same order, so global positional alignment with the caller's `keys` slice is preserved without a scatter step.
+
+**No sort.** This is deliberately the unsorted counterpart of `MultiGetSorted` — chunks are sliced off the caller's key array as-is. Sorting per chunk would help block-based table block-walk locality, but it also forces a scatter back to caller order; that variant (`ParMultiGetSorted`) is left for later if measurements show the unsorted-parallel ceiling isn't enough.
+
+Chunk size is `keys.len().div_ceil(num_threads).max(1)` so the empty-keys and `keys.len() < num_threads` cases stay legal (`slice::chunks(0)` panics).
+
 ## Why PlainTable + mmap + NoopTransform + Vector memtable (plain backend)
 
 PlainTable is RocksDB's hash-indexed SST format — built for in-memory point-lookup workloads. It has hard prerequisites:

--- a/.memory/io_rocksdb_store.md
+++ b/.memory/io_rocksdb_store.md
@@ -42,6 +42,18 @@ The caller constructs the `ReadBatchBuilder` (which owns Arrow column encoders a
 
 **Positional alignment** (every input key must produce exactly one output slot) is still preserved — the store calls either `add_row` or `add_empty` for each key, and the inverse-permutation table on the `sort_keys = true` path restores caller order before the loop.
 
+## Why `ReadMethod::ParGet` exists alongside `Get`
+
+`Get` walks `keys.iter()` and calls `db.get_pinned_cf_opt` once per key on a single core. For a 1k-key fetch every lookup is independent CPU-bound work (PlainTable hash probe + memcpy into the pinned slice), so the loop is embarrassingly parallel. `ParGet` is the same loop with `keys.par_iter()` — rayon's global pool (sized to `num_cpus`) fans the work out, and `par_iter().collect()` preserves input order so positional alignment with the caller's `keys` slice holds **without** a scatter step (unlike `MultiGetSorted`, which has to undo a key-bytes sort before handing slices to the builder).
+
+Only the rocksdb lookup phase is parallelized — the downstream `for r in &raw { builder.add_row(...) }` loop stays serial because the Arrow encoders mutate column buffers in order.
+
+**Why a new variant rather than replacing `Get`**: keeps the sequential path so benchmarks can A/B the two, and avoids a silent regression on small key batches where rayon scheduling overhead dominates the per-key work. The choice is one config flip in `PlainConfig::read_method` / `BlockConfig::read_method`.
+
+**Why rayon's global pool, not a per-store custom pool**: no thread-count knob to misconfigure, and the global pool is shared across whatever else might use rayon (today: nothing) — if that becomes a real contention source later it's easy to switch to a `ThreadPoolBuilder` owned by `RocksDBStore`. Pre-alpha defaults beat premature configurability.
+
+`DBPinnableSlice<'_>`, `&DB`, `&ColumnFamily`, `&ReadOptions` are all `Send + Sync` in rocksdb-0.24 — no wrapping or `unsafe` is needed to share them across rayon workers.
+
 ## Why PlainTable + mmap + NoopTransform + Vector memtable (plain backend)
 
 PlainTable is RocksDB's hash-indexed SST format — built for in-memory point-lookup workloads. It has hard prerequisites:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1680,6 +1680,7 @@ dependencies = [
  "murr",
  "parquet",
  "rand",
+ "rayon",
  "rocksdb",
  "rstest",
  "rustc-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ bincode = { version = "2", features = ["serde"] }
 indexmap = { version = "2", features = ["serde"] }
 rocksdb = "0.24"
 itertools = "0.14"
+rayon = "1"
 
 [dev-dependencies]
 murr = { path = ".", features = ["testutil"] }

--- a/benches/read_block.rs
+++ b/benches/read_block.rs
@@ -14,7 +14,9 @@ use common::read_bench::{BenchOpts, run_read_bench};
 fn bench(c: &mut Criterion) {
     let dataset = Dataset::new(100_000_000, 10);
     let tmp = TempDir::new().unwrap();
-    let store = RocksDBStore::open_block(tmp.path(), &BlockConfig::default()).unwrap();
+    let mut config = BlockConfig::default();
+    config.read_method = murr::io::store::rocksdb::ReadMethod::ParMultiGet;
+    let store = RocksDBStore::open_block(tmp.path(), &config).unwrap();
     let store = Arc::new(RwLock::new(store));
     let table = Table::create(store, "bench", dataset.table_schema().clone()).unwrap();
     let opts = BenchOpts {

--- a/benches/read_plain.rs
+++ b/benches/read_plain.rs
@@ -14,7 +14,9 @@ use common::read_bench::{BenchOpts, run_read_bench};
 fn bench(c: &mut Criterion) {
     let dataset = Dataset::new(100_000_000, 10);
     let tmp = TempDir::new().unwrap();
-    let store = RocksDBStore::open_plain(tmp.path(), &PlainConfig::default()).unwrap();
+    let mut config = PlainConfig::default();
+    config.read_method = murr::io::store::rocksdb::ReadMethod::Get;
+    let store = RocksDBStore::open_plain(tmp.path(), &config).unwrap();
     let store = Arc::new(RwLock::new(store));
     let table = Table::create(store, "bench", dataset.table_schema().clone()).unwrap();
     let opts = BenchOpts {

--- a/benches/read_plain.rs
+++ b/benches/read_plain.rs
@@ -15,7 +15,7 @@ fn bench(c: &mut Criterion) {
     let dataset = Dataset::new(100_000_000, 10);
     let tmp = TempDir::new().unwrap();
     let mut config = PlainConfig::default();
-    config.read_method = murr::io::store::rocksdb::ReadMethod::Get;
+    config.read_method = murr::io::store::rocksdb::ReadMethod::ParMultiGet;
     let store = RocksDBStore::open_plain(tmp.path(), &config).unwrap();
     let store = Arc::new(RwLock::new(store));
     let table = Table::create(store, "bench", dataset.table_schema().clone()).unwrap();

--- a/src/io/store/rocksdb/block.rs
+++ b/src/io/store/rocksdb/block.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::io::store::rocksdb::ReadMethod;
 use crate::io::store::rocksdb::plain::{
-    default_data_block_hash_ratio, default_disable_auto_compactions,
-    default_target_file_size_base, default_write_buffer_size,
+    default_data_block_hash_ratio, default_disable_auto_compactions, default_target_file_size_base,
+    default_write_buffer_size,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -74,7 +74,7 @@ impl Default for BlockConfig {
 }
 
 fn default_block_read_method() -> ReadMethod {
-    ReadMethod::MultiGetSorted
+    ReadMethod::ParMultiGet
 }
 
 fn default_true() -> bool {

--- a/src/io/store/rocksdb/mod.rs
+++ b/src/io/store/rocksdb/mod.rs
@@ -21,6 +21,7 @@ pub enum ReadMethod {
     MultiGet,
     MultiGetSorted,
     Get,
+    ParGet,
 }
 
 pub struct RocksDBStore {
@@ -130,6 +131,19 @@ impl RocksDBStore {
             .map(|k| self.db.get_pinned_cf_opt(cf, k, &self.read_opts))
             .collect()
     }
+
+    fn read_get_parallel<'a>(
+        &'a self,
+        cf: &ColumnFamily,
+        keys: &[&[u8]],
+    ) -> Vec<Result<Option<DBPinnableSlice<'a>>, rocksdb::Error>> {
+        use rayon::prelude::*;
+        // par_iter().collect() preserves input order, so positional alignment
+        // with the caller's keys slice holds without a scatter step.
+        keys.par_iter()
+            .map(|k| self.db.get_pinned_cf_opt(cf, k, &self.read_opts))
+            .collect()
+    }
 }
 
 impl Store for RocksDBStore {
@@ -180,6 +194,7 @@ impl Store for RocksDBStore {
             ReadMethod::MultiGet => self.read_multiget(cf, keys),
             ReadMethod::MultiGetSorted => self.read_multiget_sorted(cf, keys),
             ReadMethod::Get => self.read_get(cf, keys),
+            ReadMethod::ParGet => self.read_get_parallel(cf, keys),
         };
         for r in &raw {
             match r {
@@ -249,10 +264,17 @@ mod tests {
         store
     }
 
+    fn open_block_par_get(path: &Path) -> RocksDBStore {
+        let mut store = open_block(path);
+        store.read_method = ReadMethod::ParGet;
+        store
+    }
+
     #[rstest]
     #[case::plain(open_plain)]
     #[case::block(open_block)]
     #[case::block_get(open_block_get)]
+    #[case::block_par_get(open_block_par_get)]
     fn round_trip(#[case] open: Opener) {
         let dir = TempDir::new().unwrap();
         let mut store = open(dir.path());
@@ -280,6 +302,7 @@ mod tests {
     #[case::plain(open_plain)]
     #[case::block(open_block)]
     #[case::block_get(open_block_get)]
+    #[case::block_par_get(open_block_par_get)]
     fn read_preserves_caller_key_order(#[case] open: Opener) {
         let dir = TempDir::new().unwrap();
         let mut store = open(dir.path());
@@ -306,6 +329,7 @@ mod tests {
     #[case::plain(open_plain)]
     #[case::block(open_block)]
     #[case::block_get(open_block_get)]
+    #[case::block_par_get(open_block_par_get)]
     fn missing_key_yields_none(#[case] open: Opener) {
         let dir = TempDir::new().unwrap();
         let mut store = open(dir.path());

--- a/src/io/store/rocksdb/mod.rs
+++ b/src/io/store/rocksdb/mod.rs
@@ -22,6 +22,7 @@ pub enum ReadMethod {
     MultiGetSorted,
     Get,
     ParGet,
+    ParMultiGet,
 }
 
 pub struct RocksDBStore {
@@ -138,10 +139,23 @@ impl RocksDBStore {
         keys: &[&[u8]],
     ) -> Vec<Result<Option<DBPinnableSlice<'a>>, rocksdb::Error>> {
         use rayon::prelude::*;
-        // par_iter().collect() preserves input order, so positional alignment
-        // with the caller's keys slice holds without a scatter step.
         keys.par_iter()
             .map(|k| self.db.get_pinned_cf_opt(cf, k, &self.read_opts))
+            .collect()
+    }
+
+    fn read_multiget_parallel<'a>(
+        &'a self,
+        cf: &ColumnFamily,
+        keys: &[&[u8]],
+    ) -> Vec<Result<Option<DBPinnableSlice<'a>>, rocksdb::Error>> {
+        use rayon::prelude::*;
+        let chunk_size = keys.len().div_ceil(rayon::current_num_threads()).max(1);
+        keys.par_chunks(chunk_size)
+            .flat_map_iter(|chunk| {
+                self.db
+                    .batched_multi_get_cf_opt(cf, chunk, false, &self.read_opts)
+            })
             .collect()
     }
 }
@@ -195,6 +209,7 @@ impl Store for RocksDBStore {
             ReadMethod::MultiGetSorted => self.read_multiget_sorted(cf, keys),
             ReadMethod::Get => self.read_get(cf, keys),
             ReadMethod::ParGet => self.read_get_parallel(cf, keys),
+            ReadMethod::ParMultiGet => self.read_multiget_parallel(cf, keys),
         };
         for r in &raw {
             match r {
@@ -270,11 +285,18 @@ mod tests {
         store
     }
 
+    fn open_block_par_multi_get(path: &Path) -> RocksDBStore {
+        let mut store = open_block(path);
+        store.read_method = ReadMethod::ParMultiGet;
+        store
+    }
+
     #[rstest]
     #[case::plain(open_plain)]
     #[case::block(open_block)]
     #[case::block_get(open_block_get)]
     #[case::block_par_get(open_block_par_get)]
+    #[case::block_par_multi_get(open_block_par_multi_get)]
     fn round_trip(#[case] open: Opener) {
         let dir = TempDir::new().unwrap();
         let mut store = open(dir.path());
@@ -303,6 +325,7 @@ mod tests {
     #[case::block(open_block)]
     #[case::block_get(open_block_get)]
     #[case::block_par_get(open_block_par_get)]
+    #[case::block_par_multi_get(open_block_par_multi_get)]
     fn read_preserves_caller_key_order(#[case] open: Opener) {
         let dir = TempDir::new().unwrap();
         let mut store = open(dir.path());
@@ -311,7 +334,12 @@ mod tests {
         put(
             &mut store,
             "users",
-            &[("alice", b"a"), ("bob", b"b"), ("carol", b"c"), ("dave", b"d")],
+            &[
+                ("alice", b"a"),
+                ("bob", b"b"),
+                ("carol", b"c"),
+                ("dave", b"d"),
+            ],
         );
 
         // Mix sorted/unsorted keys, including a miss in the middle.
@@ -330,6 +358,7 @@ mod tests {
     #[case::block(open_block)]
     #[case::block_get(open_block_get)]
     #[case::block_par_get(open_block_par_get)]
+    #[case::block_par_multi_get(open_block_par_multi_get)]
     fn missing_key_yields_none(#[case] open: Opener) {
         let dir = TempDir::new().unwrap();
         let mut store = open(dir.path());

--- a/src/io/store/rocksdb/plain.rs
+++ b/src/io/store/rocksdb/plain.rs
@@ -47,7 +47,7 @@ impl Default for PlainConfig {
 }
 
 fn default_plain_read_method() -> ReadMethod {
-    ReadMethod::MultiGet
+    ReadMethod::ParGet
 }
 
 fn default_bloom_bits() -> i32 {


### PR DESCRIPTION
Benches:

```
Plain:

ParGet:         [167.21 µs 169.21 µs 171.81 µs]
Get:            [819.70 µs 821.08 µs 822.47 µs]
MultiGet:       [914.40 µs 919.61 µs 926.17 µs]
MultiGetSorted: [809.11 µs 810.75 µs 812.50 µs]
ParMultiGet:    [233.92 µs 236.63 µs 239.45 µs]

Block:

ParGet:         [452.14 µs 457.71 µs 463.65 µs]
Get:            [2.7992 ms 2.8082 ms 2.8176 ms]
MultiGet:       [2.4785 ms 2.4842 ms 2.4918 ms]
MultiGetSorted: [2.4850 ms 2.4914 ms 2.4997 ms]
ParMultiGet:    [564.59 µs 569.10 µs 573.88 µs]
```

4x improvement on plain and 5x improvement on block!!!