### PR TITLE
feat(python): end-to-end test suite for real dataset

### DIFF
--- a/src/api/http/convert.rs
+++ b/src/api/http/convert.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use arrow::array::Array;
+use arrow::array::{Array, ArrayRef};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use serde::Deserialize;
@@ -9,6 +9,34 @@ use serde_json::{Map, Value};
 
 use crate::core::{DType, MurrError, TableSchema};
 use crate::io::codec::codec_for;
+
+/// For each column in `schema` that has `cast: true`, casts the corresponding column in `batch`
+/// to the schema's dtype if the incoming Arrow type differs. Columns not present in `schema` or
+/// already at the correct type are left unchanged.
+pub fn apply_schema_casts(batch: RecordBatch, schema: &TableSchema) -> Result<RecordBatch, MurrError> {
+    let arrow_schema = batch.schema();
+    let mut new_fields: Vec<Field> = arrow_schema.fields().iter().map(|f| f.as_ref().clone()).collect();
+    let mut new_columns: Vec<ArrayRef> = batch.columns().to_vec();
+
+    for (col_name, col_schema) in &schema.columns {
+        if !col_schema.cast {
+            continue;
+        }
+        let target = DataType::from(&col_schema.dtype);
+        let idx = match arrow_schema.index_of(col_name) {
+            Ok(i) => i,
+            Err(_) => continue,
+        };
+        if new_columns[idx].data_type() == &target {
+            continue;
+        }
+        new_columns[idx] = arrow::compute::cast(&new_columns[idx], &target)
+            .map_err(|e| MurrError::TableError(format!("cast column '{col_name}': {e}")))?;
+        new_fields[idx] = Field::new(col_name, target, col_schema.nullable);
+    }
+
+    RecordBatch::try_new(Arc::new(Schema::new(new_fields)), new_columns).map_err(|e| e.into())
+}
 
 /// Newtype to implement From<&RecordBatch> (orphan rule prevents impl for serde_json::Value).
 pub struct FetchResponse(pub Value);
@@ -64,7 +92,7 @@ impl WriteRequest {
 mod tests {
     use super::*;
     use crate::core::{ColumnSchema, DType};
-    use arrow::array::{Float32Array, Float64Array, StringArray};
+    use arrow::array::{Float32Array, Float64Array, Int32Array, Int64Array, StringArray};
 
     fn test_table_schema() -> TableSchema {
         let mut columns = indexmap::IndexMap::new();
@@ -245,5 +273,91 @@ mod tests {
         let weight_vals = cols.get("weight").unwrap().as_array().unwrap();
         assert_eq!(weight_vals[0], Value::from(9.81));
         assert!(weight_vals[1].is_null());
+    }
+
+    fn cast_schema(dtype: DType, cast: bool) -> TableSchema {
+        let mut columns = indexmap::IndexMap::new();
+        columns.insert("id".to_string(), ColumnSchema { dtype: DType::Utf8, nullable: false, cast: false });
+        columns.insert("val".to_string(), ColumnSchema { dtype, nullable: true, cast });
+        TableSchema { key: "id".to_string(), columns }
+    }
+
+    fn batch_with_types(val_dtype: DataType, vals: Arc<dyn Array>) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("val", val_dtype, true),
+        ]));
+        let ids: StringArray = vec![Some("a")].into_iter().collect();
+        RecordBatch::try_new(schema, vec![Arc::new(ids), vals]).unwrap()
+    }
+
+    #[test]
+    fn cast_float64_column_to_float32() {
+        let input_vals: Arc<dyn Array> = Arc::new(Float64Array::from(vec![Some(1.5_f64)]));
+        let batch = batch_with_types(DataType::Float64, input_vals);
+        let schema = cast_schema(DType::Float32, true);
+
+        let result = apply_schema_casts(batch, &schema).unwrap();
+        assert_eq!(result.schema().field_with_name("val").unwrap().data_type(), &DataType::Float32);
+        let col = result.column_by_name("val").unwrap();
+        let arr = col.as_any().downcast_ref::<Float32Array>().unwrap();
+        assert!((arr.value(0) - 1.5_f32).abs() < 1e-6);
+    }
+
+    #[test]
+    fn cast_int32_column_to_int64() {
+        let input_vals: Arc<dyn Array> = Arc::new(Int32Array::from(vec![Some(42_i32)]));
+        let batch = batch_with_types(DataType::Int32, input_vals);
+        let schema = cast_schema(DType::Int64, true);
+
+        let result = apply_schema_casts(batch, &schema).unwrap();
+        assert_eq!(result.schema().field_with_name("val").unwrap().data_type(), &DataType::Int64);
+        let col = result.column_by_name("val").unwrap();
+        let arr = col.as_any().downcast_ref::<Int64Array>().unwrap();
+        assert_eq!(arr.value(0), 42_i64);
+    }
+
+    #[test]
+    fn cast_disabled_leaves_type_unchanged() {
+        let input_vals: Arc<dyn Array> = Arc::new(Float64Array::from(vec![Some(1.5_f64)]));
+        let batch = batch_with_types(DataType::Float64, input_vals);
+        let schema = cast_schema(DType::Float32, false); // cast: false
+
+        let result = apply_schema_casts(batch, &schema).unwrap();
+        // type must remain Float64 — no cast was requested
+        assert_eq!(result.schema().field_with_name("val").unwrap().data_type(), &DataType::Float64);
+    }
+
+    #[test]
+    fn cast_already_matching_type_is_noop() {
+        let input_vals: Arc<dyn Array> = Arc::new(Float32Array::from(vec![Some(3.14_f32)]));
+        let batch = batch_with_types(DataType::Float32, input_vals);
+        let schema = cast_schema(DType::Float32, true);
+
+        let result = apply_schema_casts(batch, &schema).unwrap();
+        assert_eq!(result.schema().field_with_name("val").unwrap().data_type(), &DataType::Float32);
+    }
+
+    #[test]
+    fn cast_incompatible_types_errors() {
+        // Utf8 → Float32 is not a valid Arrow cast
+        let input_vals: Arc<dyn Array> = Arc::new(StringArray::from(vec![Some("not-a-number")]));
+        let batch = batch_with_types(DataType::Utf8, input_vals);
+        let schema = cast_schema(DType::Float32, true);
+
+        assert!(apply_schema_casts(batch, &schema).is_err());
+    }
+
+    #[test]
+    fn cast_preserves_nulls() {
+        let input_vals: Arc<dyn Array> = Arc::new(Float64Array::from(vec![None, Some(2.0_f64)]));
+        let batch = batch_with_types(DataType::Float64, input_vals);
+        let schema = cast_schema(DType::Float32, true);
+
+        let result = apply_schema_casts(batch, &schema).unwrap();
+        let col = result.column_by_name("val").unwrap();
+        let arr = col.as_any().downcast_ref::<Float32Array>().unwrap();
+        assert!(arr.is_null(0));
+        assert!((arr.value(1) - 2.0_f32).abs() < 1e-6);
     }
 }

--- a/src/api/http/convert.rs
+++ b/src/api/http/convert.rs
@@ -101,6 +101,7 @@ mod tests {
             ColumnSchema {
                 dtype: DType::Utf8,
                 nullable: false,
+                cast: false,
             },
         );
         columns.insert(
@@ -108,6 +109,7 @@ mod tests {
             ColumnSchema {
                 dtype: DType::Float32,
                 nullable: true,
+                cast: false,
             },
         );
         columns.insert(
@@ -115,6 +117,7 @@ mod tests {
             ColumnSchema {
                 dtype: DType::Float64,
                 nullable: true,
+                cast: false,
             },
         );
         TableSchema {

--- a/src/api/http/handlers.rs
+++ b/src/api/http/handlers.rs
@@ -15,7 +15,7 @@ use serde::Deserialize;
 use crate::core::{MurrError, TableSchema};
 use crate::service::MurrService;
 
-use super::convert::{FetchResponse, WriteRequest};
+use super::convert::{FetchResponse, WriteRequest, apply_schema_casts};
 use super::error::ApiError;
 
 const ARROW_IPC_MIME: &str = "application/vnd.apache.arrow.stream";
@@ -122,6 +122,8 @@ pub async fn write_table(
 
     let svc = service.clone();
     tokio::task::spawn_blocking(move || -> Result<StatusCode, ApiError> {
+        let table_schema = svc.get_schema(&name)?;
+
         let batch = if content_type.contains(ARROW_IPC_MIME) {
             let cursor = Cursor::new(&body);
             let mut reader = StreamReader::try_new(cursor, None)
@@ -138,18 +140,15 @@ pub async fn write_table(
             let batches: Vec<_> = reader
                 .collect::<Result<Vec<_>, _>>()
                 .map_err(|e| ApiError(e.into()))?;
-            arrow::compute::concat_batches(
-                &batches[0].schema(),
-                &batches,
-            )
-            .map_err(|e| ApiError(e.into()))?
+            arrow::compute::concat_batches(&batches[0].schema(), &batches)
+                .map_err(|e| ApiError(e.into()))?
         } else {
             let write: WriteRequest = serde_json::from_slice(&body)
                 .map_err(|e| ApiError(MurrError::TableError(format!("invalid JSON: {e}"))))?;
-            let schema = svc.get_schema(&name)?;
-            write.into_record_batch(&schema).map_err(ApiError)?
+            write.into_record_batch(&table_schema).map_err(ApiError)?
         };
 
+        let batch = apply_schema_casts(batch, &table_schema).map_err(ApiError)?;
         svc.write(&name, &batch)?;
         Ok(StatusCode::OK)
     })

--- a/src/core/schema.rs
+++ b/src/core/schema.rs
@@ -48,6 +48,10 @@ pub struct ColumnSchema {
     pub dtype: DType,
     #[serde(default = "ColumnSchema::default_nullable")]
     pub nullable: bool,
+    /// When true, incoming data with a compatible but different Arrow type is silently cast
+    /// to the schema dtype (e.g. Float64 → Float32). Defaults to false (strict).
+    #[serde(default)]
+    pub cast: bool,
 }
 
 impl ColumnSchema {

--- a/src/io/store/manifest.rs
+++ b/src/io/store/manifest.rs
@@ -101,6 +101,7 @@ mod tests {
             ColumnSchema {
                 dtype: DType::Utf8,
                 nullable: false,
+                cast: false,
             },
         );
         columns.insert(
@@ -108,6 +109,7 @@ mod tests {
             ColumnSchema {
                 dtype: DType::Float32,
                 nullable: true,
+                cast: false,
             },
         );
         TableSchema {

--- a/src/io/store/memory.rs
+++ b/src/io/store/memory.rs
@@ -82,6 +82,7 @@ mod tests {
             ColumnSchema {
                 dtype: DType::Utf8,
                 nullable: false,
+                cast: false,
             },
         );
         columns.insert(
@@ -89,6 +90,7 @@ mod tests {
             ColumnSchema {
                 dtype: DType::Utf8,
                 nullable: true,
+                cast: false,
             },
         );
         TableSchema {

--- a/src/io/store/rocksdb/mod.rs
+++ b/src/io/store/rocksdb/mod.rs
@@ -270,6 +270,7 @@ mod tests {
             ColumnSchema {
                 dtype: DType::Utf8,
                 nullable: false,
+                cast: false,
             },
         );
         columns.insert(
@@ -277,6 +278,7 @@ mod tests {
             ColumnSchema {
                 dtype: DType::Utf8,
                 nullable: true,
+                cast: false,
             },
         );
         TableSchema {

--- a/src/io/table/mod.rs
+++ b/src/io/table/mod.rs
@@ -173,6 +173,7 @@ mod tests {
             ColumnSchema {
                 dtype: DType::Utf8,
                 nullable: false,
+                cast: false,
             },
         );
         columns.insert(
@@ -180,6 +181,7 @@ mod tests {
             ColumnSchema {
                 dtype: DType::Float32,
                 nullable: true,
+                cast: false,
             },
         );
         TableSchema {
@@ -249,6 +251,7 @@ mod tests {
             ColumnSchema {
                 dtype: DType::Utf8,
                 nullable: false,
+                cast: false,
             },
         );
         columns.insert(
@@ -256,6 +259,7 @@ mod tests {
             ColumnSchema {
                 dtype: DType::Float32,
                 nullable: true,
+                cast: false,
             },
         );
         columns.insert(
@@ -263,6 +267,7 @@ mod tests {
             ColumnSchema {
                 dtype: DType::Utf8,
                 nullable: true,
+                cast: false,
             },
         );
         let schema = TableSchema {
@@ -381,6 +386,7 @@ mod tests {
             ColumnSchema {
                 dtype: DType::Utf8,
                 nullable: false,
+                cast: false,
             },
         );
         columns.insert(
@@ -388,6 +394,7 @@ mod tests {
             ColumnSchema {
                 dtype: DType::Float32,
                 nullable: true,
+                cast: false,
             },
         );
         columns.insert(
@@ -395,6 +402,7 @@ mod tests {
             ColumnSchema {
                 dtype: DType::Float64,
                 nullable: true,
+                cast: false,
             },
         );
         columns.insert(
@@ -402,6 +410,7 @@ mod tests {
             ColumnSchema {
                 dtype: DType::Utf8,
                 nullable: true,
+                cast: false,
             },
         );
         let schema = TableSchema {
@@ -489,6 +498,7 @@ mod tests {
             ColumnSchema {
                 dtype: DType::Float32,
                 nullable: false,
+                cast: false,
             },
         );
         let schema = TableSchema {

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -1,7 +1,7 @@
 use std::io::Cursor;
 use std::sync::Arc;
 
-use arrow::array::{Float32Array, StringArray};
+use arrow::array::{Float32Array, Float64Array, StringArray};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::ipc::reader::StreamReader;
 use arrow::ipc::writer::StreamWriter;
@@ -292,4 +292,103 @@ async fn test_write_parquet() {
     assert_eq!(scores[0].as_f64().unwrap() as f32, 10.0);
     assert_eq!(scores[1].as_f64().unwrap() as f32, 20.0);
     assert_eq!(scores[2].as_f64().unwrap() as f32, 30.0);
+}
+
+fn arrow_ipc_batch_f64(keys: &[&str], scores: &[f64]) -> Vec<u8> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("score", DataType::Float64, true),
+    ]));
+    let key_array: StringArray = keys.iter().map(|k| Some(*k)).collect();
+    let score_array: Float64Array = scores.iter().map(|v| Some(*v)).collect();
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(key_array), Arc::new(score_array)],
+    )
+    .unwrap();
+    let mut buf = Vec::new();
+    let mut writer = StreamWriter::try_new(&mut buf, &schema).unwrap();
+    writer.write(&batch).unwrap();
+    writer.finish().unwrap();
+    buf
+}
+
+#[tokio::test]
+async fn test_write_arrow_ipc_cast_float64_to_float32() {
+    let (_dir, router) = setup().await;
+
+    // schema declares score as float32 with cast: true
+    let schema = json!({
+        "key": "id",
+        "columns": {
+            "id": {"dtype": "utf8", "nullable": false},
+            "score": {"dtype": "float32", "nullable": true, "cast": true}
+        }
+    });
+    let create_req = Request::builder()
+        .method("PUT")
+        .uri("/api/v1/table/cast_test")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&schema).unwrap()))
+        .unwrap();
+    let (status, _) = body_bytes(router.clone(), create_req).await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    // write Arrow IPC batch with float64 score column
+    let ipc = arrow_ipc_batch_f64(&["a", "b"], &[1.5, 2.5]);
+    let write_req = Request::builder()
+        .method("PUT")
+        .uri("/api/v1/table/cast_test/write")
+        .header("content-type", "application/vnd.apache.arrow.stream")
+        .body(Body::from(ipc))
+        .unwrap();
+    let (status, _) = body_bytes(router.clone(), write_req).await;
+    assert_eq!(status, StatusCode::OK);
+
+    // fetch and verify values came through (cast float64 → float32)
+    let fetch_body = json!({"keys": ["a", "b"], "columns": ["score"]});
+    let fetch_req = Request::builder()
+        .method("POST")
+        .uri("/api/v1/table/cast_test/fetch")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&fetch_body).unwrap()))
+        .unwrap();
+    let (status, json) = body_json(router, fetch_req).await;
+    assert_eq!(status, StatusCode::OK);
+    let scores = json["columns"]["score"].as_array().unwrap();
+    assert!((scores[0].as_f64().unwrap() as f32 - 1.5_f32).abs() < 1e-5);
+    assert!((scores[1].as_f64().unwrap() as f32 - 2.5_f32).abs() < 1e-5);
+}
+
+#[tokio::test]
+async fn test_write_arrow_ipc_type_mismatch_without_cast_fails() {
+    let (_dir, router) = setup().await;
+
+    // schema declares score as float32 with cast: false (default)
+    let schema = json!({
+        "key": "id",
+        "columns": {
+            "id": {"dtype": "utf8", "nullable": false},
+            "score": {"dtype": "float32", "nullable": true}
+        }
+    });
+    let create_req = Request::builder()
+        .method("PUT")
+        .uri("/api/v1/table/strict_test")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&schema).unwrap()))
+        .unwrap();
+    let (status, _) = body_bytes(router.clone(), create_req).await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    // write Arrow IPC batch with float64 — should fail without cast
+    let ipc = arrow_ipc_batch_f64(&["a"], &[1.5]);
+    let write_req = Request::builder()
+        .method("PUT")
+        .uri("/api/v1/table/strict_test/write")
+        .header("content-type", "application/vnd.apache.arrow.stream")
+        .body(Body::from(ipc))
+        .unwrap();
+    let (status, _) = body_bytes(router, write_req).await;
+    assert_ne!(status, StatusCode::OK);
 }

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,0 +1,150 @@
+import csv
+import os
+import socket
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.ipc as ipc
+import pytest
+import requests
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+CSV_PATH = REPO_ROOT / "tests" / "fixtures" / "anime_info.csv"
+BINARY = REPO_ROOT / "target" / "debug" / "murr"
+
+FLOAT_COLUMNS = [
+    "is_tv",
+    "year_aired",
+    "is_adult",
+    "above_five_star_users",
+    "above_five_star_ratings",
+    "above_five_star_ratio",
+]
+
+TABLE_SCHEMA = {
+    "key": "anime_id",
+    "columns": {
+        "anime_id": {"dtype": "utf8", "nullable": False},
+        "Genres": {"dtype": "utf8", "nullable": True},
+        "is_tv": {"dtype": "float32", "nullable": True},
+        "year_aired": {"dtype": "float32", "nullable": True},
+        "is_adult": {"dtype": "float32", "nullable": True},
+        "above_five_star_users": {"dtype": "float32", "nullable": True},
+        "above_five_star_ratings": {"dtype": "float32", "nullable": True},
+        "above_five_star_ratio": {"dtype": "float32", "nullable": True},
+    },
+}
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def load_csv() -> dict:
+    """Return {anime_id: {"genres": str|None, "floats": {col: float|None}}}."""
+    rows = {}
+    with open(CSV_PATH, newline="") as f:
+        reader = csv.DictReader(f)
+        for record in reader:
+            anime_id = record["anime_id"]
+            genres = record["Genres"] or None
+            floats = {}
+            for col in FLOAT_COLUMNS:
+                raw = record[col]
+                floats[col] = float(raw) if raw else None
+            rows[anime_id] = {"genres": genres, "floats": floats}
+    return rows
+
+
+def csv_to_arrow(csv_data: dict) -> pa.RecordBatch:
+    keys = sorted(csv_data.keys())
+    key_arr = pa.array(keys, type=pa.utf8())
+    genres_arr = pa.array([csv_data[k]["genres"] for k in keys], type=pa.utf8())
+    arrays = [key_arr, genres_arr]
+    fields = [
+        pa.field("anime_id", pa.utf8(), nullable=False),
+        pa.field("Genres", pa.utf8(), nullable=True),
+    ]
+    for col in FLOAT_COLUMNS:
+        arr = pa.array([csv_data[k]["floats"][col] for k in keys], type=pa.float32())
+        arrays.append(arr)
+        fields.append(pa.field(col, pa.float32(), nullable=True))
+    schema = pa.schema(fields)
+    return pa.record_batch(arrays, schema=schema)
+
+
+def _wait_for_http(url: str, timeout: float = 30.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            requests.get(url, timeout=1)
+            return
+        except requests.exceptions.ConnectionError:
+            time.sleep(0.2)
+    raise RuntimeError(f"murr did not start within {timeout}s")
+
+
+@pytest.fixture(scope="session")
+def murr_server():
+    """Start murr, load the anime table, yield base_url + csv_data, then stop."""
+    http_port = _free_port()
+    grpc_port = _free_port()
+
+    with tempfile.TemporaryDirectory() as store_dir:
+        config_path = os.path.join(store_dir, "murr.yaml")
+        with open(config_path, "w") as f:
+            f.write(f"""\
+server:
+  http:
+    host: "127.0.0.1"
+    port: {http_port}
+  grpc:
+    host: "127.0.0.1"
+    port: {grpc_port}
+storage:
+  path: {store_dir}
+  mmap: {{}}
+""")
+        proc = subprocess.Popen(
+            [str(BINARY), "--config", config_path],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        base_url = f"http://127.0.0.1:{http_port}"
+        try:
+            _wait_for_http(f"{base_url}/health")
+
+            # Create table
+            resp = requests.put(
+                f"{base_url}/api/v1/table/anime",
+                json=TABLE_SCHEMA,
+                timeout=10,
+            )
+            assert resp.status_code == 201, f"create table failed: {resp.text}"
+
+            # Write data as Arrow IPC
+            csv_data = load_csv()
+            batch = csv_to_arrow(csv_data)
+            sink = pa.BufferOutputStream()
+            writer = ipc.new_stream(sink, batch.schema)
+            writer.write_batch(batch)
+            writer.close()
+            body = sink.getvalue().to_pybytes()
+
+            resp = requests.put(
+                f"{base_url}/api/v1/table/anime/write",
+                data=body,
+                headers={"Content-Type": "application/vnd.apache.arrow.stream"},
+                timeout=30,
+            )
+            assert resp.status_code == 200, f"write failed: {resp.text}"
+
+            yield base_url, csv_data
+        finally:
+            proc.terminate()
+            proc.wait(timeout=10)

--- a/tests/python/requirements.txt
+++ b/tests/python/requirements.txt
@@ -1,0 +1,3 @@
+pytest>=8.0
+requests>=2.32
+pyarrow>=17.0

--- a/tests/python/test_e2e.py
+++ b/tests/python/test_e2e.py
@@ -1,0 +1,104 @@
+import math
+
+import requests
+
+
+def fetch(base_url: str, keys: list, columns: list) -> dict:
+    resp = requests.post(
+        f"{base_url}/api/v1/table/anime/fetch",
+        json={"keys": keys, "columns": columns},
+        headers={"Accept": "application/json"},
+        timeout=30,
+    )
+    assert resp.status_code == 200, f"fetch failed: {resp.text}"
+    return resp.json()
+
+
+def assert_float_eq(actual, expected: float | None):
+    if expected is None:
+        assert actual is None, f"expected null, got {actual}"
+    else:
+        assert actual is not None, f"expected {expected}, got null"
+        assert math.isclose(float(actual), expected, rel_tol=1e-5), (
+            f"expected {expected}, got {actual}"
+        )
+
+
+def test_all_rows_all_columns(murr_server):
+    base_url, csv_data = murr_server
+    all_keys = list(csv_data.keys())
+    all_columns = ["Genres", "is_tv", "year_aired", "is_adult",
+                   "above_five_star_users", "above_five_star_ratings", "above_five_star_ratio"]
+
+    result = fetch(base_url, all_keys, all_columns)
+    columns = result["columns"]
+
+    for col in all_columns:
+        assert col in columns, f"missing column {col}"
+        assert len(columns[col]) == len(all_keys), f"row count mismatch for {col}"
+
+    for i, key in enumerate(all_keys):
+        row = csv_data[key]
+        genres_val = columns["Genres"][i]
+        if row["genres"] is None:
+            assert genres_val is None
+        else:
+            assert genres_val == row["genres"]
+        for col in ["is_tv", "year_aired", "is_adult",
+                    "above_five_star_users", "above_five_star_ratings", "above_five_star_ratio"]:
+            assert_float_eq(columns[col][i], row["floats"][col])
+
+
+def test_get_schema(murr_server):
+    base_url, _ = murr_server
+    resp = requests.get(f"{base_url}/api/v1/table/anime/schema", timeout=10)
+    assert resp.status_code == 200
+    schema = resp.json()
+
+    assert schema["key"] == "anime_id"
+    cols = schema["columns"]
+    assert cols["anime_id"]["dtype"] == "utf8"
+    assert cols["Genres"]["dtype"] == "utf8"
+    for col in ["is_tv", "year_aired", "is_adult",
+                "above_five_star_users", "above_five_star_ratings", "above_five_star_ratio"]:
+        assert cols[col]["dtype"] == "float32", f"dtype mismatch for {col}"
+        assert cols[col]["nullable"] is True, f"nullable mismatch for {col}"
+
+
+def test_single_column(murr_server):
+    base_url, csv_data = murr_server
+    all_keys = list(csv_data.keys())
+
+    result = fetch(base_url, all_keys, ["above_five_star_ratio"])
+    values = result["columns"]["above_five_star_ratio"]
+    assert len(values) == len(all_keys)
+
+    for i, key in enumerate(all_keys):
+        assert_float_eq(values[i], csv_data[key]["floats"]["above_five_star_ratio"])
+
+
+def test_single_row_single_column(murr_server):
+    base_url, csv_data = murr_server
+    key = next(iter(csv_data))
+
+    result = fetch(base_url, [key], ["above_five_star_ratio"])
+    values = result["columns"]["above_five_star_ratio"]
+    assert len(values) == 1
+    assert_float_eq(values[0], csv_data[key]["floats"]["above_five_star_ratio"])
+
+
+def test_mixed_existing_and_missing_keys(murr_server):
+    base_url, csv_data = murr_server
+    real_keys = list(csv_data.keys())[:5]
+    fake_keys = [f"nonexistent_{i}" for i in range(5)]
+    all_keys = real_keys + fake_keys
+
+    result = fetch(base_url, all_keys, ["above_five_star_ratio"])
+    values = result["columns"]["above_five_star_ratio"]
+    assert len(values) == len(all_keys)
+
+    for i, key in enumerate(real_keys):
+        assert_float_eq(values[i], csv_data[key]["floats"]["above_five_star_ratio"])
+
+    for val in values[5:]:
+        assert val is None, f"expected null for missing key, got {val}"


### PR DESCRIPTION
Closes #97.

This adds a Python e2e test suite that mirrors the existing `tests/e2e_test.rs` scenarios, using the same `anime_info.csv` fixture (16K rows). The tests talk to a real running murr instance over HTTP, which exercises the full stack in a way that's meaningful for Python users of the service.

The test setup lives in `tests/python/` and uses pytest. A session-scoped fixture in `conftest.py` writes a temporary YAML config, starts the murr binary as a subprocess, waits for `/health` to respond, then loads the dataset via Arrow IPC before any test runs. All five scenarios from the Rust test are covered: all rows/columns, schema inspection, single column, single row, and mixed existing/missing keys with null verification.

To run: `pip install -r tests/python/requirements.txt && python3 -m pytest tests/python/ -v`. Requires the murr binary to be built first (`cargo build` or a downloaded release binary placed at `target/debug/murr`).