### PR TITLE
drop table support

### DIFF
--- a/.memory/api.md
+++ b/.memory/api.md
@@ -19,6 +19,7 @@
 | GET | `/api/v1/table` | `list_tables` | JSON map of table name → schema |
 | GET | `/api/v1/table/{name}/schema` | `get_schema` | JSON schema for one table |
 | PUT | `/api/v1/table/{name}` | `create_table` | Accepts `TableSchema` JSON, returns 201 |
+| DELETE | `/api/v1/table/{name}` | `drop_table` | Drops table + CF + manifest entry, returns 204 (404 if unknown) |
 | POST | `/api/v1/table/{name}/fetch` | `fetch` | Read data (content negotiation on response) |
 | PUT | `/api/v1/table/{name}/write` | `write_table` | Write data (content negotiation on request) |
 

--- a/.memory/io_service_integration.md
+++ b/.memory/io_service_integration.md
@@ -36,7 +36,9 @@ impl<S: Store> MurrService<S> {
 }
 ```
 
-One `Arc<StdRwLock<S>>` shared across all tables (one DB, many CFs when backed by RocksDB). Each table holds its own clone of the `Arc` and locks it internally per call. The service's public methods (`new`, `create`, `write`, `read`, `list_tables`, `get_schema`) are all **sync**.
+One `Arc<StdRwLock<S>>` shared across all tables (one DB, many CFs when backed by RocksDB). Each table holds its own clone of the `Arc` and locks it internally per call. The service's public methods (`new`, `create`, `drop_table`, `write`, `read`, `list_tables`, `get_schema`) are all **sync**.
+
+**Table drop (added 2026-09-11)** — `Store::drop_table` mirrors `create_table` in reverse: manifest entry removed in memory, RocksDB `drop_cf`, then manifest persisted. `MurrService::drop_table` removes the registry entry under the tables write lock *before* calling the store, so no concurrent reader can obtain a `Table` whose CF is mid-teardown (`Table<S>` carries no CF handle, only the `Arc<RwLock<S>>` and schema, so dropping it is free). Named `drop_table` rather than `drop` to avoid clashing with `std::mem::drop` and clippy's `should_implement_trait`. Exposed over HTTP only (`DELETE /api/v1/table/{name}`); Flight stays read-only, consistent with it having no create either.
 
 **Why generic over `S: Store` rather than concrete `RocksDBStore`** — leaves room for future backends (the trait-level abstraction was the only reason to do it; no second impl exists today). Constructor is **pure-generic**: the caller builds `Arc<RwLock<S>>` and hands it in. RocksDB-specific `Config → Store` wiring lives in `RocksDBStore::open_from_config(&config.storage)`; the service layer no longer matches on `BackendConfig`. `main.rs` monomorphises to `MurrService<RocksDBStore>`; tests/benches do the same explicitly via `RocksDBStore::open_from_config`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ Python bindings live in a separate repo: [shuttie/murr-python](https://github.co
 
 **`service/`** — High-level service wrapping the storage layer
 - `MurrService` — Owns `Config`, holds `tokio::sync::RwLock<HashMap<String, Table<RocksDBStore>>>` and a shared `Arc<std::sync::RwLock<RocksDBStore>>`; constructor takes `Config` (not a path)
-- `create(table_name, schema)` → `write(table_name, batch)` → `read(table_name, keys, columns)` flow
+- `create(table_name, schema)` → `write(table_name, batch)` → `read(table_name, keys, columns)` → `drop_table(table_name)` flow
 - `config()` accessor exposes config to API layers (serve methods read listen addresses from it)
 - Startup rehydration: walks `store.manifest().tables` and opens a `Table` per entry; missing manifest entries → CF is invisible to the service
 
@@ -136,7 +136,7 @@ storage:
   mmap: {}              # or `block: {}` — pick exactly one; inner keys are RocksDB tunables
 ```
 
-Tables are created at runtime via the API (`PUT /api/v1/table/{name}`) with a `TableSchema` JSON body specifying `key`, and `columns` (each with `dtype` and optional `nullable`).
+Tables are created at runtime via the API (`PUT /api/v1/table/{name}`) with a `TableSchema` JSON body specifying `key`, and `columns` (each with `dtype` and optional `nullable`). `DELETE /api/v1/table/{name}` drops a table (data, column family, and manifest entry); the name can be reused afterwards.
 
 Supported dtypes: `utf8`, `bool`, `int8`, `int16`, `int32`, `int64`, `uint8`, `uint16`, `uint32`, `uint64`, `float32`, `float64`
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -65,6 +65,17 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+    delete:
+      summary: Drop a table
+      operationId: dropTable
+      description: Removes the table, its data, and its manifest entry. The name can be reused afterwards.
+      parameters:
+        - $ref: "#/components/parameters/TableName"
+      responses:
+        "204":
+          description: Table dropped
+        "404":
+          $ref: "#/components/responses/NotFound"
 
   /api/v1/table/{name}/schema:
     get:

--- a/src/api/http/handlers.rs
+++ b/src/api/http/handlers.rs
@@ -67,6 +67,17 @@ pub async fn create_table<S: Store>(
     Ok(StatusCode::CREATED)
 }
 
+pub async fn drop_table<S: Store>(
+    State(service): State<Arc<MurrService<S>>>,
+    Path(name): Path<String>,
+) -> Result<StatusCode, ApiError> {
+    let svc = service.clone();
+    tokio::task::spawn_blocking(move || svc.drop_table(&name))
+        .await
+        .map_err(join_to_api_error)??;
+    Ok(StatusCode::NO_CONTENT)
+}
+
 #[derive(Deserialize)]
 pub struct FetchRequest {
     pub keys: Vec<String>,

--- a/src/api/http/mod.rs
+++ b/src/api/http/mod.rs
@@ -27,10 +27,19 @@ impl<S: Store> MurrHttpService<S> {
             .route("/openapi.json", get(handlers::openapi))
             .route("/health", get(handlers::health))
             .route("/api/v1/table", get(handlers::list_tables::<S>))
-            .route("/api/v1/table/{name}/schema", get(handlers::get_schema::<S>))
-            .route("/api/v1/table/{name}", put(handlers::create_table::<S>))
+            .route(
+                "/api/v1/table/{name}/schema",
+                get(handlers::get_schema::<S>),
+            )
+            .route(
+                "/api/v1/table/{name}",
+                put(handlers::create_table::<S>).delete(handlers::drop_table::<S>),
+            )
             .route("/api/v1/table/{name}/fetch", post(handlers::fetch::<S>))
-            .route("/api/v1/table/{name}/write", put(handlers::write_table::<S>))
+            .route(
+                "/api/v1/table/{name}/write",
+                put(handlers::write_table::<S>),
+            )
             .layer(DefaultBodyLimit::max(
                 self.service.config().server.http.max_payload_size,
             ))

--- a/src/io/store/memory.rs
+++ b/src/io/store/memory.rs
@@ -25,6 +25,12 @@ impl Store for MemoryStore {
         Ok(())
     }
 
+    fn drop_table(&mut self, table: &str) -> Result<(), MurrError> {
+        self.manifest.del_table(table)?;
+        self.tables.remove(table);
+        Ok(())
+    }
+
     fn read(
         &self,
         table: &str,
@@ -154,6 +160,28 @@ mod tests {
         store.create_table("users", &schema()).unwrap();
         let err = store.create_table("users", &schema()).unwrap_err();
         assert!(matches!(err, MurrError::TableAlreadyExists(_)));
+    }
+
+    #[test]
+    fn drop_table_removes_data_and_manifest_entry() {
+        let mut store = MemoryStore::new();
+        store.create_table("users", &schema()).unwrap();
+        put(&mut store, "users", &[("alice", b"a")]);
+
+        store.drop_table("users").unwrap();
+
+        assert!(!store.manifest().contains("users"));
+        let err = store
+            .write("users", [KeyValue::new(*b"x", *b"y")])
+            .unwrap_err();
+        assert!(matches!(err, MurrError::TableNotFound(_)));
+    }
+
+    #[test]
+    fn drop_unknown_table_fails() {
+        let mut store = MemoryStore::new();
+        let err = store.drop_table("nope").unwrap_err();
+        assert!(matches!(err, MurrError::TableNotFound(_)));
     }
 
     #[test]

--- a/src/io/store/mod.rs
+++ b/src/io/store/mod.rs
@@ -29,6 +29,7 @@ impl KeyValue {
 
 pub trait Store: Send + Sync + 'static {
     fn create_table(&mut self, table: &str, schema: &TableSchema) -> Result<(), MurrError>;
+    fn drop_table(&mut self, table: &str) -> Result<(), MurrError>;
     fn write(
         &mut self,
         table: &str,

--- a/src/io/store/rocksdb/mod.rs
+++ b/src/io/store/rocksdb/mod.rs
@@ -213,6 +213,13 @@ impl Store for RocksDBStore {
         Ok(())
     }
 
+    fn drop_table(&mut self, table: &str) -> Result<(), MurrError> {
+        self.manifest.del_table(table)?;
+        self.db.drop_cf(table)?;
+        self.manifest.to_file(&self.manifest_path())?;
+        Ok(())
+    }
+
     fn manifest(&self) -> &Manifest {
         &self.manifest
     }
@@ -499,6 +506,44 @@ mod tests {
         let store = open(dir.path());
         assert_eq!(store.manifest().schema("users"), Some(&users));
         assert_eq!(store.manifest().schema("products"), Some(&products));
+    }
+
+    #[rstest]
+    #[case::plain(open_plain)]
+    #[case::block(open_block)]
+    fn drop_table_persists_across_reopen(#[case] open: Opener) {
+        let dir = TempDir::new().unwrap();
+        {
+            let mut store = open(dir.path());
+            store.create_table("users", &schema("id")).unwrap();
+            put(&mut store, "users", &[("alice", b"a")]);
+
+            store.drop_table("users").unwrap();
+
+            assert!(!store.manifest().contains("users"));
+            let err = store
+                .write("users", [KeyValue::new(*b"x", *b"y")])
+                .unwrap_err();
+            assert!(matches!(err, MurrError::TableNotFound(_)));
+        }
+
+        let mut store = open(dir.path());
+        assert!(!store.manifest().contains("users"));
+        // Recreating after drop must start empty, not resurrect old rows.
+        store.create_table("users", &schema("id")).unwrap();
+        let lookup: [&[u8]; 1] = [b"alice"];
+        let got = fetch(&store, "users", &lookup);
+        assert_eq!(got[0], None);
+    }
+
+    #[rstest]
+    #[case::plain(open_plain)]
+    #[case::block(open_block)]
+    fn drop_unknown_table_fails(#[case] open: Opener) {
+        let dir = TempDir::new().unwrap();
+        let mut store = open(dir.path());
+        let err = store.drop_table("nope").unwrap_err();
+        assert!(matches!(err, MurrError::TableNotFound(_)));
     }
 
     #[rstest]

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -69,6 +69,18 @@ impl<S: Store> MurrService<S> {
         Ok(())
     }
 
+    pub fn drop_table(&self, table_name: &str) -> Result<(), MurrError> {
+        let mut tables = self.tables.write().unwrap_or_else(PoisonError::into_inner);
+        // Unregister first so no reader can grab a Table whose CF is being torn down.
+        tables
+            .remove(table_name)
+            .ok_or_else(|| MurrError::TableNotFound(table_name.to_string()))?;
+        self.store
+            .write()
+            .unwrap_or_else(PoisonError::into_inner)
+            .drop_table(table_name)
+    }
+
     pub fn write(&self, table_name: &str, batch: &RecordBatch) -> Result<(), MurrError> {
         let tables = self.tables.read().unwrap_or_else(PoisonError::into_inner);
         let table = tables
@@ -253,6 +265,62 @@ mod tests {
         assert_eq!(vals.value(0), 1.0);
         assert_eq!(vals.value(1), 2.0);
         assert_eq!(vals.value(2), 3.0);
+    }
+
+    #[test]
+    fn test_drop_table_then_recreate_with_new_schema() {
+        let dir = TempDir::new().unwrap();
+        let svc = build_service(test_config(&dir));
+
+        svc.create("t", test_schema()).unwrap();
+        svc.write("t", &test_batch(&["a"], &[1.0])).unwrap();
+
+        svc.drop_table("t").unwrap();
+        assert!(svc.list_tables().is_empty());
+        assert!(matches!(
+            svc.read("t", &["a"], &["score"]),
+            Err(MurrError::TableNotFound(_))
+        ));
+        assert!(matches!(
+            svc.drop_table("t"),
+            Err(MurrError::TableNotFound(_))
+        ));
+
+        let mut new_schema = test_schema();
+        new_schema.columns.insert(
+            "extra".to_string(),
+            ColumnSchema {
+                dtype: DTypeName::Utf8,
+                nullable: true,
+            },
+        );
+        svc.create("t", new_schema.clone()).unwrap();
+        assert_eq!(svc.get_schema("t").unwrap(), new_schema);
+
+        let result = svc.read("t", &["a"], &["score"]).unwrap();
+        let vals = result
+            .column(0)
+            .as_any()
+            .downcast_ref::<Float32Array>()
+            .unwrap();
+        assert!(vals.is_null(0));
+    }
+
+    #[test]
+    fn test_dropped_table_does_not_return_on_startup() {
+        let dir = TempDir::new().unwrap();
+
+        {
+            let svc = build_service(test_config(&dir));
+            svc.create("users", test_schema()).unwrap();
+            svc.create("gone", test_schema()).unwrap();
+            svc.drop_table("gone").unwrap();
+        }
+
+        let svc = build_service(test_config(&dir));
+        let tables = svc.list_tables();
+        assert!(tables.contains_key("users"));
+        assert!(!tables.contains_key("gone"));
     }
 
     #[test]

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -171,6 +171,38 @@ async fn test_list_and_get_table() {
 }
 
 #[tokio::test]
+async fn test_drop_table() {
+    let (_dir, router) = setup().await;
+    let schema = serde_json::to_vec(&table_schema_json()).unwrap();
+
+    let req = Request::put("/api/v1/table/features")
+        .header("content-type", "application/json")
+        .body(Body::from(schema))
+        .unwrap();
+    let (status, _) = body_bytes(router.clone(), req).await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let req = Request::delete("/api/v1/table/features")
+        .body(Body::empty())
+        .unwrap();
+    let (status, _) = body_bytes(router.clone(), req).await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+
+    let req = Request::get("/api/v1/table/features/schema")
+        .body(Body::empty())
+        .unwrap();
+    let (status, _) = body_json(router.clone(), req).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    let req = Request::delete("/api/v1/table/features")
+        .body(Body::empty())
+        .unwrap();
+    let (status, json) = body_json(router, req).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert!(json["error"].is_string());
+}
+
+#[tokio::test]
 async fn test_full_round_trip() {
     let (_dir, router) = setup().await;
 


### PR DESCRIPTION
The Java binding I'm writing had no way to remove a table: the service and HTTP layer only exposed create. `Manifest::del_table` already existed but nothing called it, so this wires drop through the whole stack.

  **Why**

  Bindings need a way to tear down tables they created, for tests and for schema changes. Today the only option is deleting the data directory.

  **What changed**

  - `Store::drop_table`, implemented for RocksDB (manifest entry removed, `drop_cf`, manifest persisted, the reverse of create) and for `MemoryStore`.
  - `MurrService::drop_table` unregisters the table under the write lock before calling the store, so a concurrent reader can't pick up a `Table` whose column family is mid-teardown.
  - `DELETE /api/v1/table/{name}` over HTTP: 204 on success, 404 for an unknown name. The name can be reused with a different schema afterwards.
  - Flight stays read-only, same as it is for create.

  **Decisions**

  Named `drop_table` rather than `drop` to stay clear of `std::mem::drop` and the clippy trait-name lint. Registry is cleared before the store so the failure mode on a store error is a missing table, not a half-visible one.
